### PR TITLE
Bug fix: `case class Node(children: List[Node])`

### DIFF
--- a/src/main/scala/inox/ast/Definitions.scala
+++ b/src/main/scala/inox/ast/Definitions.scala
@@ -286,6 +286,7 @@ trait Definitions { self: Trees =>
       def flattenTuples(s: Seq[Type]): Seq[Type] = s match {
         case Nil => Nil
         case (head: TupleType) +: tail => flattenTuples(head.bases ++ tail)
+        case (head: MapType) +: tail => flattenTuples(head.to +: tail) // Because Map has a default.
         case head +: tail => head +: flattenTuples(tail)
       }
       def rec(adt: TypedADTDefinition, seen: Set[TypedADTDefinition]): Boolean = {

--- a/src/main/scala/inox/ast/Definitions.scala
+++ b/src/main/scala/inox/ast/Definitions.scala
@@ -289,10 +289,10 @@ trait Definitions { self: Trees =>
             tsort.constructors.exists(rec(_, seen + tsort))
 
           case tcons: TypedADTConstructor =>
-            tcons.fieldsTypes.flatMap(tpe => typeOps.collect {
+            tcons.fieldsTypes.flatMap{
               case t: ADTType => Set(t.getADT)
               case _ => Set.empty[TypedADTDefinition]
-            } (tpe)).forall(rec(_, seen + tcons))
+            }.forall(rec(_, seen + tcons))
         })
       }
 


### PR DESCRIPTION
The previous hasInstance function was buggy and cannot cover the following case:

    case class Node(children: List[Node])

because it originally unwrapped `List[Node]` to `Set(List[Node], Node)`
and thus was blocked because Node was re-used.