### PR TITLE
Incoherency of pretty-printing fixed

### DIFF
--- a/src/main/scala/inox/ast/Printers.scala
+++ b/src/main/scala/inox/ast/Printers.scala
@@ -243,7 +243,7 @@ trait Printers {
       if (rs.isEmpty) {
         p"{* -> $dflt}"
       } else {
-        p"{${rs.toMap.toSeq}, * -> $dflt}"
+        p"{${rs.toSeq}, * -> $dflt}"
       }
     case Not(ElementOfSet(e, s)) => p"$e \u2209 $s"
     case ElementOfSet(e, s) => p"$e \u2208 $s"

--- a/src/main/scala/inox/ast/Printers.scala
+++ b/src/main/scala/inox/ast/Printers.scala
@@ -237,8 +237,8 @@ trait Printers {
     case BVLShiftRight(l, r) => optP {
       p"$l >>> $r"
     }
-    case fs @ FiniteSet(rs, _) => p"{${rs.distinct}}"
-    case fs @ FiniteBag(rs, _) => p"{${rs.toMap.toSeq}}"
+    case fs @ FiniteSet(rs, _) => p"{${rs}}"
+    case fs @ FiniteBag(rs, _) => p"{${rs.toSeq}}"
     case fm @ FiniteMap(rs, dflt, _, _) =>
       if (rs.isEmpty) {
         p"{* -> $dflt}"


### PR DESCRIPTION
I removed the intermediate conversion to a `Map[Expr, Expr]` because the printing is not consistent with the tree definition, and thus would result in a different parsing if we had parsing, and hence to a bug. Look the following example:

    val tr = Map("A" -> "B", "A" -> "C", * -> "...")
    tr("hello")

From the semantics of Map, it's clear that the second `A` overrides the first; therefore the output is `"C"`.
However, if after re-printing and parsing, the order is changed:

    val tr = Map("A" -> "C", "A" -> "B", * -> "...")
    tr("hello")

the output changes to "B". This can happen because the `.toMap.toSeq` takes hashcodes on expressions to rely on sorting.

Another example is when I define translation maps, I don't want to have the order to change because they might have be groupped semantically. That is, the same way when we do program repair, we don't change the order of variables at first.