### PR TITLE
Fix printer for Char literals

### DIFF
--- a/src/main/scala/inox/ast/Printers.scala
+++ b/src/main/scala/inox/ast/Printers.scala
@@ -164,7 +164,7 @@ trait Printer {
     case FractionLiteral(n, d) =>
       if (d == 1) p"$n"
       else p"$n/$d"
-    case CharLiteral(v) => p"$v"
+    case CharLiteral(v) => p"'${StringEscapeUtils.escapeJava(v.toString)}'"
     case BooleanLiteral(v) => p"$v"
     case UnitLiteral() => p"()"
     case StringLiteral(v) =>


### PR DESCRIPTION
Obviously this is a minor fix.

Previously `'\n'` (and other escaped char) was rendered as a newline. Now it's rendered as expected, with single quotes.