### PR TITLE
Compute relative path for DefinedPosition

### DIFF
--- a/src/main/scala/inox/utils/Positions.scala
+++ b/src/main/scala/inox/utils/Positions.scala
@@ -63,11 +63,17 @@ object Position {
 
 abstract class DefinedPosition extends Position {
   override def toString = line+":"+col
-  override def fullString = file.getPath+":"+line+":"+col
+  override def fullString = path+":"+line+":"+col
   override def isDefined = true
 
   def focusBegin: OffsetPosition
   def focusEnd: OffsetPosition
+
+  private lazy val path = {
+    val base = new File(".").getCanonicalFile.toPath
+    val absolute = file.getAbsoluteFile.toPath
+    base.relativize(absolute).toString
+  }
 }
 
 case class OffsetPosition(line: Int, col: Int, point: Int, file: File) extends DefinedPosition {


### PR DESCRIPTION
This makes path more consistent when printed, especially when loading caches.

Instead of printing sometimes a relative path (because the `File` was created with a relative path) or sometimes a full path (e.g. when a position is recovered from a cache, the `File` is reconstructed with an absolute path), with this patch all paths are printed with a relative path to the current working directory.