### PR TITLE
Improve consistency of command line names

### DIFF
--- a/src/main/scala/inox/Model.scala
+++ b/src/main/scala/inox/Model.scala
@@ -2,7 +2,7 @@
 
 package inox
 
-object optPrintChooses extends FlagOptionDef("printchooses", false)
+object optPrintChooses extends FlagOptionDef("print-chooses", false)
 
 object Model {
   def empty(p: Program, ctx: Context): p.Model = new Model {

--- a/src/main/scala/inox/ast/Printers.scala
+++ b/src/main/scala/inox/ast/Printers.scala
@@ -7,9 +7,9 @@ import utils._
 import org.apache.commons.lang3.StringEscapeUtils
 import scala.language.implicitConversions
 
-object optPrintPositions extends FlagOptionDef("printpositions", false)
-object optPrintUniqueIds extends FlagOptionDef("printids",       false)
-object optPrintTypes     extends FlagOptionDef("printtypes",     false)
+object optPrintPositions extends FlagOptionDef("print-positions", false)
+object optPrintUniqueIds extends FlagOptionDef("print-ids",       false)
+object optPrintTypes     extends FlagOptionDef("print-types",     false)
 
 trait Printers { self: Trees =>
 

--- a/src/main/scala/inox/evaluators/ContextualEvaluator.scala
+++ b/src/main/scala/inox/evaluators/ContextualEvaluator.scala
@@ -3,7 +3,7 @@
 package inox
 package evaluators
 
-object optMaxCalls extends IntOptionDef("maxcalls", 50000, "<PosInt> | -1 (unbounded)")
+object optMaxCalls extends IntOptionDef("max-calls", 50000, "<PosInt> | -1 (unbounded)")
 
 trait ContextualEvaluator extends Evaluator {
   import context._

--- a/src/main/scala/inox/evaluators/Evaluator.scala
+++ b/src/main/scala/inox/evaluators/Evaluator.scala
@@ -3,7 +3,7 @@
 package inox
 package evaluators
 
-object optIgnoreContracts extends FlagOptionDef("ignorecontracts", false)
+object optIgnoreContracts extends FlagOptionDef("ignore-contracts", false)
 
 trait Evaluator {
   val program: Program

--- a/src/main/scala/inox/solvers/Solver.scala
+++ b/src/main/scala/inox/solvers/Solver.scala
@@ -5,8 +5,8 @@ package solvers
 
 import utils._
 
-object optCheckModels  extends FlagOptionDef("checkmodels", false)
-object optSilentErrors extends FlagOptionDef("silenterrors", false)
+object optCheckModels  extends FlagOptionDef("check-models", false)
+object optSilentErrors extends FlagOptionDef("silent-errors", false)
 
 case object DebugSectionSolver extends DebugSection("solver")
 

--- a/src/main/scala/inox/solvers/package.scala
+++ b/src/main/scala/inox/solvers/package.scala
@@ -22,7 +22,7 @@ package object solvers {
   }
 
   object optAssumeChecked extends OptionDef[PurityOptions] {
-    val name = "assumechecked"
+    val name = "assume-checked"
     val default = PurityOptions.Unchecked
     val parser = (str: String) => str match {
       case "false" => Some(PurityOptions.Unchecked)
@@ -33,7 +33,7 @@ package object solvers {
     val usageRhs = s"--$name=(false|checked|total)"
   }
 
-  object optNoSimplifications extends FlagOptionDef("nosimplifications", false)
+  object optNoSimplifications extends FlagOptionDef("no-simplifications", false)
 
   class SimplificationOptions(val simplify: Boolean)
   object SimplificationOptions {

--- a/src/main/scala/inox/solvers/unrolling/UnrollingSolver.scala
+++ b/src/main/scala/inox/solvers/unrolling/UnrollingSolver.scala
@@ -12,10 +12,10 @@ import combinators._
 
 import scala.collection.mutable.{Map => MutableMap}
 
-object optUnrollFactor      extends IntOptionDef("unrollfactor", default = 1, "<PosInt>")
-object optFeelingLucky      extends FlagOptionDef("feelinglucky", false)
-object optUnrollAssumptions extends FlagOptionDef("unrollassumptions", false)
-object optModelFinding      extends IntOptionDef("modelfinding", 0, "<PosInt> | 0 (off)") {
+object optUnrollFactor      extends IntOptionDef("unroll-factor", default = 1, "<PosInt>")
+object optFeelingLucky      extends FlagOptionDef("feeling-lucky", false)
+object optUnrollAssumptions extends FlagOptionDef("unroll-assumptions", false)
+object optModelFinding      extends IntOptionDef("model-finding", 0, "<PosInt> | 0 (off)") {
   override val parser: OptionParsers.OptionParser[Int] = (s => s match {
     case "" => Some(1)
     case _ => OptionParsers.intParser(s)


### PR DESCRIPTION
Using `-` to separate words in command line options.