### PR TITLE
Quick'n'dirty fix for SimplifierWithPC

### DIFF
--- a/src/main/scala/inox/transformers/SimplifierWithPC.scala
+++ b/src/main/scala/inox/transformers/SimplifierWithPC.scala
@@ -216,11 +216,11 @@ trait SimplifierWithPC extends TransformerWithPC { self =>
     }
   }
 
-  def isPure(e: Expr, path: CNFPath): Boolean = simplify(e, path)._2
+  def isPure(e: Expr, path: CNFPath): Boolean = synchronized { simplify(e, path)._2 }
 
   private val simplifyCache = new LruCache[Expr, (CNFPath, Expr, Boolean)](100)
 
-  def simplify(e: Expr, path: CNFPath): (Expr, Boolean) = e match {
+  private def simplify(e: Expr, path: CNFPath): (Expr, Boolean) = e match {
     case e if path contains e => (BooleanLiteral(true), true)
     case e if path contains not(e) => (BooleanLiteral(false), true)
 
@@ -423,7 +423,7 @@ trait SimplifierWithPC extends TransformerWithPC { self =>
     (re, pe)
   }
 
-  override protected def rec(e: Expr, path: CNFPath): Expr = {
+  override protected def rec(e: Expr, path: CNFPath): Expr = synchronized {
     stack = if (stack.isEmpty) Nil else (stack.head + 1) :: stack.tail
     val (re, pe) = simplify(e, path)
     purity = if (stack.isEmpty) purity else pe :: purity


### PR DESCRIPTION
This ensures that the trait is thread safe. This is required for the concurrency introduced by epfl-lara/stainless#76.

Ideally, it's internal state shouldn't be mutable and/or the critical section should be reduced to its minimal size for better throughput efficiency.

I couldn't provide a more efficient patch mainly because this feature is not well documented and I couldn't infer all the assumptions easily. This is therefore more a temporary workaround than a proper patch. I basically added  `synchronized` on all publicly available methods' body.