### PR TITLE
Ensure variables are available in the scope when used

### DIFF
--- a/src/it/resources/regression/tip/SAT/BraunTree.scala-1.tip
+++ b/src/it/resources/regression/tip/SAT/BraunTree.scala-1.tip
@@ -1,22 +1,22 @@
 (declare-datatypes () ((Tree!3 (Leaf!3) (Node!3 (value!6 (_ BitVec 32)) (left!8 Tree!3) (right!8 Tree!3)))))
 
-(declare-const |error: Match is non-exhaustive!58| (_ BitVec 32))
+(declare-fun |error: Match is non-exhaustive!58| () (_ BitVec 32))
 
 (define-fun-rec height!0 ((tree!1 Tree!3)) (_ BitVec 32) (ite (is-Node!3 tree!1) (let ((l!0 (height!0 (left!8 tree!1)))) (let ((r!0 (height!0 (right!8 tree!1)))) (let ((max!0 (ite (bvsgt l!0 r!0) l!0 r!0))) (bvadd #b00000000000000000000000000000001 max!0)))) (ite (is-Leaf!3 tree!1) #b00000000000000000000000000000000 |error: Match is non-exhaustive!58|)))
 
-(declare-const |error: Match is non-exhaustive!62| Bool)
+(declare-fun |error: Match is non-exhaustive!62| () Bool)
 
 (define-fun-rec isBraun!0 ((tree!2 Tree!3)) Bool (ite (is-Node!3 tree!2) (and (and (isBraun!0 (left!8 tree!2)) (isBraun!0 (right!8 tree!2))) (let ((l!1 (height!0 (left!8 tree!2)))) (let ((r!1 (height!0 (right!8 tree!2)))) (or (= l!1 r!1) (= l!1 (bvadd r!1 #b00000000000000000000000000000001)))))) (ite (is-Leaf!3 tree!2) true |error: Match is non-exhaustive!62|)))
 
 (declare-const tree!0 Tree!3)
 
-(declare-const |error: Match is non-exhaustive!27| Tree!3)
+(declare-fun |error: Match is non-exhaustive!27| () Tree!3)
 
 (define-fun-rec insert!0 ((tree!0 Tree!3) (x!0 (_ BitVec 32))) Tree!3 (assume (isBraun!0 tree!0) (let ((res!0 (ite (is-Node!3 tree!0) (Node!3 (value!6 tree!0) (insert!0 (left!8 tree!0) x!0) (right!8 tree!0)) (ite (is-Leaf!3 tree!0) (Node!3 x!0 Leaf!3 Leaf!3) |error: Match is non-exhaustive!27|)))) (assume (isBraun!0 res!0) res!0))))
 
 (declare-const x!0 (_ BitVec 32))
 
-(declare-const |error: Match is non-exhaustive!76| Tree!3)
+(declare-fun |error: Match is non-exhaustive!76| () Tree!3)
 
 (assert (not (=> (isBraun!0 tree!0) (isBraun!0 (ite (is-Node!3 tree!0) (Node!3 (value!6 tree!0) (insert!0 (left!8 tree!0) x!0) (right!8 tree!0)) (ite (is-Leaf!3 tree!0) (Node!3 x!0 Leaf!3 Leaf!3) |error: Match is non-exhaustive!76|))))))
 

--- a/src/it/resources/regression/tip/SAT/PositiveMap.scala-0.tip
+++ b/src/it/resources/regression/tip/SAT/PositiveMap.scala-0.tip
@@ -1,6 +1,6 @@
 (declare-datatypes () ((List!5 (Nil!2) (Cons!2 (head!5 (_ BitVec 32)) (tail!7 List!5)))))
 
-(declare-const |error: Match is non-exhaustive!46| Bool)
+(declare-fun |error: Match is non-exhaustive!46| () Bool)
 
 (define-fun-rec positive!0 ((list!0 List!5)) Bool (ite (is-Cons!2 list!0) (ite (bvslt (head!5 list!0) #b00000000000000000000000000000000) false (positive!0 (tail!7 list!0))) (ite (is-Nil!2 list!0) true |error: Match is non-exhaustive!46|)))
 
@@ -10,11 +10,11 @@
 
 (declare-const f!0 (fun1!1 (_ BitVec 32) (_ BitVec 32)))
 
-(declare-const |error: Match is non-exhaustive!42| List!5)
+(declare-fun |error: Match is non-exhaustive!42| () List!5)
 
 (define-fun-rec positiveMap_failling_1!0 ((f!0 (fun1!1 (_ BitVec 32) (_ BitVec 32))) (list!1 List!5)) List!5 (let ((res!0 (ite (is-Cons!2 list!1) (let ((fh!0 (assume (@ (pre!10 f!0) (head!5 list!1)) (@ (f!32 f!0) (head!5 list!1))))) (let ((nh!0 (ite (bvslt fh!0 #b11111111111111111111111111111111) #b00000000000000000000000000000000 fh!0))) (Cons!2 nh!0 (positiveMap_failling_1!0 f!0 (tail!7 list!1))))) (ite (is-Nil!2 list!1) Nil!2 |error: Match is non-exhaustive!42|)))) (assume (positive!0 res!0) res!0)))
 
-(declare-const |error: Match is non-exhaustive!75| List!5)
+(declare-fun |error: Match is non-exhaustive!75| () List!5)
 
 (assert (not (positive!0 (ite (is-Cons!2 list!1) (let ((fh!0 (assume (@ (pre!10 f!0) (head!5 list!1)) (@ (f!32 f!0) (head!5 list!1))))) (Cons!2 (ite (bvslt fh!0 #b11111111111111111111111111111111) #b00000000000000000000000000000000 fh!0) (positiveMap_failling_1!0 f!0 (tail!7 list!1)))) (ite (is-Nil!2 list!1) Nil!2 |error: Match is non-exhaustive!75|)))))
 

--- a/src/it/resources/regression/tip/UNSAT/BinarySearchTreeQuant2.scala-0.tip
+++ b/src/it/resources/regression/tip/UNSAT/BinarySearchTreeQuant2.scala-0.tip
@@ -2,7 +2,7 @@
 
 (define-fun (par (T!2) (empty!0 () (Set T!2) (as emptyset T!2))))
 
-(declare-const |error: Match is non-exhaustive!25| (Set Int))
+(declare-fun |error: Match is non-exhaustive!25| () (Set Int))
 
 (define-fun-rec content!0 ((thiss!51 Tree!1)) (Set Int) (ite (is-Leaf!1 thiss!51) (as empty!0 (Set Int)) (ite (is-Node!1 thiss!51) (union (union (content!0 (left!3 thiss!51)) (insert (as emptyset Int) (value!2 thiss!51))) (content!0 (right!3 thiss!51))) |error: Match is non-exhaustive!25|)))
 

--- a/src/it/resources/regression/tip/UNSAT/BinarySearchTreeQuant2.scala-1.tip
+++ b/src/it/resources/regression/tip/UNSAT/BinarySearchTreeQuant2.scala-1.tip
@@ -2,7 +2,7 @@
 
 (define-fun (par (T!2) (empty!0 () (Set T!2) (as emptyset T!2))))
 
-(declare-const |error: Match is non-exhaustive!25| (Set Int))
+(declare-fun |error: Match is non-exhaustive!25| () (Set Int))
 
 (define-fun-rec content!0 ((thiss!51 Tree!17)) (Set Int) (ite (is-Leaf!17 thiss!51) (as empty!0 (Set Int)) (ite (is-Node!17 thiss!51) (union (union (content!0 (left!19 thiss!51)) (insert (as emptyset Int) (value!18 thiss!51))) (content!0 (right!19 thiss!51))) |error: Match is non-exhaustive!25|)))
 
@@ -14,11 +14,11 @@
 
 (declare-const value!1 Int)
 
-(declare-const |error: Match is non-exhaustive!51| Tree!17)
+(declare-fun |error: Match is non-exhaustive!51| () Tree!17)
 
 (define-fun-rec insert!0 ((tree!0 Tree!17) (value!1 Int)) Tree!17 (let ((res!0 (ite (is-Leaf!17 tree!0) (assume (inv!2 (Node!17 (assume (inv!2 Leaf!17) Leaf!17) value!1 (assume (inv!2 Leaf!17) Leaf!17))) (Node!17 (assume (inv!2 Leaf!17) Leaf!17) value!1 (assume (inv!2 Leaf!17) Leaf!17))) (ite (is-Node!17 tree!0) (ite (< (value!18 tree!0) value!1) (assume (inv!2 (Node!17 (left!19 tree!0) (value!18 tree!0) (insert!0 (right!19 tree!0) value!1))) (Node!17 (left!19 tree!0) (value!18 tree!0) (insert!0 (right!19 tree!0) value!1))) (ite (> (value!18 tree!0) value!1) (assume (inv!2 (Node!17 (insert!0 (left!19 tree!0) value!1) (value!18 tree!0) (right!19 tree!0))) (Node!17 (insert!0 (left!19 tree!0) value!1) (value!18 tree!0) (right!19 tree!0))) (assume (inv!2 (Node!17 (left!19 tree!0) (value!18 tree!0) (right!19 tree!0))) (Node!17 (left!19 tree!0) (value!18 tree!0) (right!19 tree!0))))) |error: Match is non-exhaustive!51|)))) (assume (= (content!0 res!0) (union (content!0 tree!0) (insert (as emptyset Int) value!1))) res!0)))
 
-(declare-const |error: Match is non-exhaustive!75| Tree!17)
+(declare-fun |error: Match is non-exhaustive!75| () Tree!17)
 
 (datatype-invariant thiss!114 Tree!17 (ite (is-Node!17 thiss!114) (inv!0 (assume (is-Node!17 thiss!114) thiss!114)) true))
 

--- a/src/it/resources/regression/tip/UNSAT/MergeSort2.scala-0.tip
+++ b/src/it/resources/regression/tip/UNSAT/MergeSort2.scala-0.tip
@@ -4,15 +4,15 @@
 
 (declare-datatypes (A0!3 A1!13) ((tuple2!4 (tuple2!5 (_1!2 A0!3) (_2!2 A1!13)))))
 
-(declare-const |error: Match is non-exhaustive!67| Int)
+(declare-fun |error: Match is non-exhaustive!67| () Int)
 
 (define-fun-rec (par (T!91) (size!0 ((thiss!106 (List!8 T!91))) Int (let ((x$1!2 (ite (is-Nil!5 thiss!106) 0 (ite (is-Cons!5 thiss!106) (+ 1 (size!0 (t!57 thiss!106))) |error: Match is non-exhaustive!67|)))) (assume (>= x$1!2 0) x$1!2)))))
 
-(declare-const |error: Match is non-exhaustive!61| (tuple2!4 (List!8 Int) (List!8 Int)))
+(declare-fun |error: Match is non-exhaustive!61| () (tuple2!4 (List!8 Int) (List!8 Int)))
 
 (define-fun (par (T!2) (empty!0 () (Bag T!2) (as bag.empty T!2))))
 
-(declare-const (par (T!0) (|error: Match is non-exhaustive!68| (Bag T!0))))
+(declare-fun (par (T!0) (|error: Match is non-exhaustive!68| () (Bag T!0))))
 
 (define-fun-rec (par (T!0) (bag!0 ((list!0 (List!8 T!0))) (Bag T!0) (ite (is-Nil!5 list!0) (as empty!0 (Bag T!0)) (ite (is-Cons!5 list!0) (bag.insert (bag!0 (t!57 list!0)) (h!50 list!0)) (as |error: Match is non-exhaustive!68| (Bag T!0)))))))
 
@@ -20,9 +20,9 @@
 
 (define-fun-rec isSorted!0 ((list!1 (List!8 Int))) Bool (ite (and (is-Cons!5 list!1) (is-Cons!5 (t!57 list!1))) (and (<= (h!50 list!1) (h!50 (t!57 list!1))) (isSorted!0 (t!57 list!1))) true))
 
-(declare-const (par (T!31) (|error: Match is non-exhaustive!7| (List!8 T!31))))
+(declare-fun (par (T!31) (|error: Match is non-exhaustive!7| () (List!8 T!31))))
 
-(declare-const (par (T!50) (|error: Match is non-exhaustive!26| (Set T!50))))
+(declare-fun (par (T!50) (|error: Match is non-exhaustive!26| () (Set T!50))))
 
 (define-fun-rec (par (T!50) (content!2 ((thiss!38 (List!8 T!50))) (Set T!50) (ite (is-Nil!5 thiss!38) (as emptyset T!50) (ite (is-Cons!5 thiss!38) (union (insert (as emptyset T!50) (h!50 thiss!38)) (content!2 (t!57 thiss!38))) (as |error: Match is non-exhaustive!26| (Set T!50)))))))
 

--- a/src/it/resources/regression/tip/UNSAT/MergeSort2.scala-1.tip
+++ b/src/it/resources/regression/tip/UNSAT/MergeSort2.scala-1.tip
@@ -6,13 +6,13 @@
 
 (declare-const l2!0 (List!16 Int))
 
-(declare-const (par (T!31) (|error: Match is non-exhaustive!7| (List!16 T!31))))
+(declare-fun (par (T!31) (|error: Match is non-exhaustive!7| () (List!16 T!31))))
 
-(declare-const (par (T!50) (|error: Match is non-exhaustive!26| (Set T!50))))
+(declare-fun (par (T!50) (|error: Match is non-exhaustive!26| () (Set T!50))))
 
 (define-fun-rec (par (T!50) (content!2 ((thiss!38 (List!16 T!50))) (Set T!50) (ite (is-Nil!13 thiss!38) (as emptyset T!50) (ite (is-Cons!13 thiss!38) (union (insert (as emptyset T!50) (h!58 thiss!38)) (content!2 (t!65 thiss!38))) (as |error: Match is non-exhaustive!26| (Set T!50)))))))
 
-(declare-const |error: Match is non-exhaustive!67| Int)
+(declare-fun |error: Match is non-exhaustive!67| () Int)
 
 (define-fun-rec (par (T!91) (size!0 ((thiss!106 (List!16 T!91))) Int (let ((x$1!2 (ite (is-Nil!13 thiss!106) 0 (ite (is-Cons!13 thiss!106) (+ 1 (size!0 (t!65 thiss!106))) |error: Match is non-exhaustive!67|)))) (assume (>= x$1!2 0) x$1!2)))))
 
@@ -20,7 +20,7 @@
 
 (define-fun (par (T!2) (empty!0 () (Bag T!2) (as bag.empty T!2))))
 
-(declare-const (par (T!0) (|error: Match is non-exhaustive!68| (Bag T!0))))
+(declare-fun (par (T!0) (|error: Match is non-exhaustive!68| () (Bag T!0))))
 
 (define-fun-rec (par (T!0) (bag!0 ((list!0 (List!16 T!0))) (Bag T!0) (ite (is-Nil!13 list!0) (as empty!0 (Bag T!0)) (ite (is-Cons!13 list!0) (bag.insert (bag!0 (t!65 list!0)) (h!58 list!0)) (as |error: Match is non-exhaustive!68| (Bag T!0)))))))
 

--- a/src/main/scala/inox/ast/Definitions.scala
+++ b/src/main/scala/inox/ast/Definitions.scala
@@ -207,8 +207,10 @@ trait Definitions { self: Trees =>
       for ((_, fd) <- functions) {
         typeCheck(fd.fullBody, fd.returnType)
 
-        def isBound(id: Identifier, path: Path) = (path isBound id) || (fd.params exists { _.id == id })
-        val unbound: Seq[Variable] = collectWithPC(fd.fullBody) { case (v: Variable, path) if !isBound(v.id, path) => v }
+        val unbound: Seq[Variable] = collectWithPC(fd.fullBody, Path.empty withBounds fd.params) {
+          case (v: Variable, path) if !(path isBound v.id) => v
+        }
+
         if (unbound.nonEmpty) {
           throw NotWellFormedException(fd, Some("Unknown variables: " + (unbound map { _.id.uniqueName } mkString ", ")))
         }

--- a/src/main/scala/inox/ast/Paths.scala
+++ b/src/main/scala/inox/ast/Paths.scala
@@ -38,19 +38,26 @@ trait Paths { self: SymbolOps with TypeOps =>
   }
 
   implicit object Path extends PathProvider[Path] {
-    final type Element = Either[(ValDef, Expr), Expr]
+    sealed abstract class Element
+    case class CloseBound(vd: ValDef, v: Expr) extends Element
+    case class OpenBound(vd: ValDef) extends Element
+    case class Condition(e: Expr) extends Element
 
-    def empty: Path = new Path(Seq.empty, Seq.empty)
+    def empty: Path = new Path(Seq.empty)
+
+    def apply(p: Element) = new Path(Seq(p))
+    def apply(p: Seq[Element]) = new Path(p)
 
     def apply(p: Expr): Path = p match {
-      case Let(i, e, b) => new Path(Seq(Left(i -> e)), Seq.empty) merge apply(b)
-      case BooleanLiteral(true) => new Path(Seq.empty, Seq.empty)
-      case _ => new Path(Seq(Right(p)), Seq.empty)
+      case Let(i, e, b) => Path(CloseBound(i, e)) merge apply(b)
+      case BooleanLiteral(true) => empty
+      case _ => Path(Condition(p))
     }
 
-    def apply(p: (ValDef, Expr)): Path = new Path(Seq(Left(p)), Seq.empty)
+    def apply(p: (ValDef, Expr)): Path = Path(CloseBound(p._1, p._2))
 
-    def apply(path: Seq[Expr]): Path = new Path(path.filterNot(_ == BooleanLiteral(true)).map(Right(_)), Seq.empty)
+    def apply(path: Seq[Expr])(implicit d: DummyImplicit): Path =
+      new Path(path filterNot { _ == BooleanLiteral(true) } map Condition)
   }
 
   /** Encodes path conditions
@@ -63,52 +70,53 @@ trait Paths { self: SymbolOps with TypeOps =>
     * not defined, whereas an encoding of let-bindings with equalities
     * could introduce non-sensical equations.
     */
-  class Path protected(val elements: Seq[Path.Element], val bounds: Seq[ValDef])
+  class Path protected(val elements: Seq[Path.Element])
     extends Printable with PathLike[Path] {
-    import Path.Element
+    import Path.{ Element, CloseBound, OpenBound, Condition }
+
+    private def :+(e: Element) = new Path(elements :+ e)
 
     /** Add a binding to this [[Path]] */
     override def withBinding(p: (ValDef, Expr)) = {
-      def exprOf(e: Element) = e match { case Right(e) => e; case Left((_, e)) => e }
-      val (before, after) = elements span (el => !exprOps.variablesOf(exprOf(el)).contains(p._1.toVariable))
-      new Path(before ++ Seq(Left(p)) ++ after, bounds)
+      val (vd, value) = p
+      val exprs = elements collect {
+        case CloseBound(_, e) => e
+        case Condition(e) => e
+      }
+      assert(exprs forall { e => !(exprOps.variablesOf(e) contains vd.toVariable) })
+      this :+ CloseBound(vd, value)
     }
 
     /** Add a bound to this [[Path]], a variable being defined but to an unknown/arbitrary value. */
-    override def withBound(b: ValDef) = new Path(elements, b +: bounds)
+    override def withBound(b: ValDef) = this :+ OpenBound(b)
 
     /** Add a condition to this [[Path]] */
     override def withCond(e: Expr): Path = e match {
       case TopLevelAnds(es) if es.size > 1 => withConds(es)
-      case Not(TopLevelOrs(es)) if es.size > 1 => withConds(es.map(not(_)))
+      case Not(TopLevelOrs(es)) if es.size > 1 => withConds(es map not)
       case _ =>
-        val notE = not(e)
-        val newElements = elements.map(_.right.map { e =>
-          simplifyByConstructors(exprOps.replace(Map(notE -> BooleanLiteral(false)), e))
-        }) :+ Right(simplifyByConstructors(conditions.foldLeft(e) { (e, c) =>
-          exprOps.replace(Map(not(c) -> BooleanLiteral(false)), e)
-        }))
+        def replaceNeg(from: Expr)(to: Expr) = exprOps.replace(Map(not(from) -> BooleanLiteral(false)), to)
 
-        new Path(newElements.filterNot(_.right.exists(_ == BooleanLiteral(true))), bounds)
+        val prefix: Seq[Element] = elements map {
+          case Condition(c) => Condition(simplifyByConstructors(replaceNeg(e)(c)))
+          case p => p
+        }
+        val last = Condition(simplifyByConstructors(conditions.foldLeft(e) { (acc, c) => replaceNeg(c)(acc) }))
+        val newElements = (prefix :+ last) filter { _ != Condition(BooleanLiteral(true)) } // simplify path
+        new Path(newElements)
     }
 
     /** Remove bound variables from this [[Path]]
       * @param ids the bound variables to remove
       */
-    def --(vds: Set[ValDef]) = new Path(elements.filterNot(_.left.exists(p => vds(p._1))), bounds filterNot vds)
+    def --(vds: Set[ValDef]) = new Path(elements filter {
+      case OpenBound(vd) if vds contains vd => false
+      case CloseBound(vd, _) if vds contains vd => false
+      case _ => true
+    })
 
     /** Appends `that` path at the end of `this` */
-    override def merge(that: Path): Path = new Path((elements ++ that.elements).distinct, that.bounds ++ bounds)
-
-    /** Transforms all expressions inside the path
-      *
-      * Expressions in a path appear both on the right-hand side of let binders
-      * and in boolean path conditions.
-      *
-      * @see [[map(fVal:Paths\.this\.trees\.ValDef=>Paths\.this\.trees\.ValDef,fExpr:Paths\.this\.trees\.Expr=>Paths\.this\.trees\.Expr):Paths\.this\.Path* map]]
-      *      for a map that can transform bindings as well
-      */
-    def map(f: Expr => Expr) = new Path(elements.map(_.left.map { case (vd, e) => vd -> f(e) }.right.map(f)), bounds)
+    override def merge(that: Path): Path = new Path((elements ++ that.elements).distinct)
 
     /** Transforms both let bindings and expressions inside the path
       *
@@ -118,10 +126,11 @@ trait Paths { self: SymbolOps with TypeOps =>
       * @see [[map(f:Paths\.this\.trees\.Expr=>Paths\.this\.trees\.Expr):Paths\.this\.Path* map]]
       *      for a map defined only on expressions
       */
-    def map(fVal: ValDef => ValDef, fExpr: Expr => Expr) = new Path(
-      elements.map(_.left.map { case (vd, e) => fVal(vd) -> fExpr(e) }.right.map(fExpr)),
-      bounds
-    )
+    def map(fVal: ValDef => ValDef, fExpr: Expr => Expr) = new Path(elements map {
+      case CloseBound(vd, e) => CloseBound(fVal(vd), fExpr(e))
+      case OpenBound(vd) => OpenBound(fVal(vd))
+      case Condition(c) => Condition(fExpr(c))
+    })
 
     /** Instantiates type parameters within the path
       *
@@ -130,32 +139,19 @@ trait Paths { self: SymbolOps with TypeOps =>
       */
     def instantiate(tps: Map[TypeParameter, Type]) = {
       val t = new TypeInstantiator(tps)
-      new Path(elements.map(_.left.map {
-        case (vd, e) => t.transform(vd) -> t.transform(e)
-      }.right.map(t.transform)), bounds)
-    }
-
-    /** Splits the path on predicate `p`
-      *
-      * The path is split into
-      * 1. the sub-path containing all conditions that pass `p` (and all let-bindings), and
-      * 2. the sequence of conditions that didn't pass `p`.
-      */
-    def partition(p: Expr => Boolean): (Path, Seq[Expr]) = {
-      val (passed, failed) = elements.partition {
-        case Right(e) => p(e)
-        case Left(_) => true
-      }
-
-      (new Path(passed, bounds), failed.flatMap(_.right.toOption))
+      new Path(elements map {
+        case CloseBound(vd, e) => CloseBound(t transform vd, t transform e)
+        case OpenBound(vd) => OpenBound(t transform vd)
+        case Condition(c) => Condition(t transform c)
+      })
     }
 
     /** Check if the path is empty
       *
       * A path is empty iff it contains no let-bindings and its path condition is trivial.
       */
-    def isEmpty = elements.forall {
-      case Right(BooleanLiteral(true)) => true
+    lazy val isEmpty = elements forall {
+      case Condition(BooleanLiteral(true)) => true
       case _ => false
     }
 
@@ -166,8 +162,8 @@ trait Paths { self: SymbolOps with TypeOps =>
       * avoiding let-binding dupplication in future path foldings.
       */
     override def negate: Path = {
-      val (outers, rest) = elements.span(_.isLeft)
-      new Path(outers :+ Right(not(fold[Expr](BooleanLiteral(true), let, trees.and(_, _))(rest))), bounds)
+      val (outers, rest) = elements span { !_.isInstanceOf[Condition] }
+      new Path(outers) :+ Condition(not(fold[Expr](BooleanLiteral(true), let, trees.and(_, _))(rest)))
     }
 
     /** Returns a new path which depends ONLY on provided ids.
@@ -185,27 +181,37 @@ trait Paths { self: SymbolOps with TypeOps =>
       */
     def filterByIds(ids: Set[Identifier]): Path = {
       def containsIds(ids: Set[Identifier])(e: Expr): Boolean = exprOps.exists {
-        case Variable(id, _, _) => ids.contains(id)
+        case Variable(id, _, _) => ids contains id
         case _ => false
       }(e)
 
-      val newElements = elements.filter{
-        case Left((vd, e)) => ids.contains(vd.id) || containsIds(ids)(e)
-        case Right(e) => containsIds(ids)(e)
+      val newElements = elements filter {
+        case CloseBound(vd, e) => (ids contains vd.id) || containsIds(ids)(e)
+        case OpenBound(vd) => ids contains vd.id
+        case Condition(e) => containsIds(ids)(e)
       }
-      new Path(newElements, bounds)
+
+      new Path(newElements)
     }
 
     /** Free variables within the path */
-    lazy val variables: Set[Variable] = fold[Set[Variable]](Set.empty,
-      (vd, e, res) => res - vd.toVariable ++ exprOps.variablesOf(e), (e, res) => res ++ exprOps.variablesOf(e)
-    )(elements)
+    lazy val freeVariables: Set[Variable] = {
+      val allVars = elements. collect { case Condition(e) => e; case CloseBound(_, e) => e }
+                            . flatMap { e => exprOps.variablesOf(e) }
+      val boundVars = bounds map { _.toVariable }
+      allVars.toSet -- boundVars
+    }
 
-    lazy val bindings: Seq[(ValDef, Expr)] = elements.collect { case Left(p) => p }
-    lazy val bound = bindings map (_._1)
-    lazy val conditions: Seq[Expr] = elements.collect { case Right(e) => e }
+    lazy val bindings: Seq[(ValDef, Expr)] = elements collect { case CloseBound(vd, e) => vd -> e }
 
-    def isBound(id: Identifier): Boolean = bindings.exists(p => p._1.id == id) || bounds.exists(_.id == id)
+    lazy val bounds: Seq[ValDef] = elements collect {
+      case CloseBound(vd, _) => vd
+      case OpenBound(vd) => vd
+    }
+
+    lazy val conditions: Seq[Expr] = elements collect { case Condition(e) => e }
+
+    def isBound(id: Identifier): Boolean = bounds exists { _.id == id }
 
     /** Fold the path elements
       *
@@ -214,8 +220,9 @@ trait Paths { self: SymbolOps with TypeOps =>
       */
     private def fold[T](base: T, combineLet: (ValDef, Expr, T) => T, combineCond: (Expr, T) => T)
                        (elems: Seq[Element]): T = elems.foldRight(base) {
-      case (Left((id, e)), res) => combineLet(id, e, res)
-      case (Right(e), res) => combineCond(e, res)
+      case (CloseBound(vd, e), res) => combineLet(vd, e, res)
+      case (Condition(e), res) => combineCond(e, res)
+      case (OpenBound(_), res) => res // FIXME should it also take a combiner for OpenBound?
     }
 
     /** Folds the path elements over a distributive proposition combinator [[combine]]
@@ -225,9 +232,11 @@ trait Paths { self: SymbolOps with TypeOps =>
       * `let a = b in combine(e1, e2)` (where a \not\in FV(e2)). This is the case for
       * - conjunction [[and]]
       * - implication [[implies]]
+      *
+      * NOTE Open bounds are lost; i.e. the generated expression can contain free variables.
       */
     private def distributiveClause(base: Expr, combine: (Expr, Expr) => Expr): Expr = {
-      val (outers, rest) = elements.span(_.isLeft)
+      val (outers, rest) = elements span { !_.isInstanceOf[Condition] }
       val inner = fold[Expr](base, let, combine)(rest)
       fold[Expr](inner, let, (_,_) => scala.sys.error("Should never happen!"))(outers)
     }
@@ -251,11 +260,11 @@ trait Paths { self: SymbolOps with TypeOps =>
       * that implies further positions.
       */
     def withShared(es: Seq[Expr], recons: (Expr, Seq[Expr]) => Expr): Expr = {
-      val (outers, rest) = elements.span(_.isLeft)
+      val (outers, rest) = elements span { !_.isInstanceOf[Condition] }
+      val bindings = rest collect { case CloseBound(vd, e) => vd -> e }
       val cond = fold[Expr](BooleanLiteral(true), let, trees.and(_, _))(rest)
 
       def wrap(e: Expr): Expr = {
-        val bindings = rest.collect { case Left((vd, e)) => vd -> e }
         val subst = bindings.map(p => p._1 -> p._1.toVariable.freshen).toMap
         val replace = exprOps.replaceFromSymbols(subst, _: Expr)
         bindings.foldRight(replace(e)) { case ((vd, e), b) => let(subst(vd).toVal, replace(e), b) }
@@ -271,16 +280,6 @@ trait Paths { self: SymbolOps with TypeOps =>
     /** Like [[toClause]] but doesn't simplify final path through constructors
       * from [[Constructors]] */
     lazy val fullClause: Expr = fold[Expr](BooleanLiteral(true), Let, And(_, _))(elements)
-
-    /** Folds the path into a boolean proposition where let-bindings are
-      * replaced by equations.
-      *
-      * CAUTION: Should only be used once INSIDE the solver!!
-      */
-    lazy val toPath: Expr = andJoin(elements.map {
-      case Left((id, e)) => Equals(id.toVariable, e)
-      case Right(e) => e
-    })
 
     override def equals(that: Any): Boolean = that match {
       case p: Path => elements == p.elements && bounds == p.bounds

--- a/src/main/scala/inox/ast/Paths.scala
+++ b/src/main/scala/inox/ast/Paths.scala
@@ -229,7 +229,7 @@ trait Paths { self: SymbolOps with TypeOps =>
                        (elems: Seq[Element]): T = elems.foldRight(base) {
       case (CloseBound(vd, e), res) => combineLet(vd, e, res)
       case (Condition(e), res) => combineCond(e, res)
-      case (OpenBound(_), res) => res // FIXME should it also take a combiner for OpenBound?
+      case (OpenBound(_), res) => res // No combiner for OpenBound
     }
 
     /** Folds the path elements over a distributive proposition combinator [[combine]]

--- a/src/main/scala/inox/ast/SymbolOps.scala
+++ b/src/main/scala/inox/ast/SymbolOps.scala
@@ -218,8 +218,9 @@ trait SymbolOps { self: TypeOps =>
 
       def isLocal(e: Expr, path: Path): Boolean = {
         val vs = variablesOf(e)
-        val tvs = vs.flatMap(v => varSubst.get(v.id).map(Variable(_, v.tpe, v.flags)))
-        (tvars & tvs).isEmpty && (path.bindings.map(_._1.toVariable).toSet & tvs).isEmpty
+        val tvs = vs flatMap { v => varSubst.get(v.id) map { Variable(_, v.tpe, v.flags) } }
+        val pathVars = path.bounds.toSet map { vd: ValDef => vd.toVariable }
+        (tvars & tvs).isEmpty && (pathVars & tvs).isEmpty
       }
 
       transformWithPC(body)((e, env, op) => e match {
@@ -719,7 +720,7 @@ trait SymbolOps { self: TypeOps =>
         Stream(BooleanLiteral(false), BooleanLiteral(true))
       case BVType(size) =>
         val count = BigInt(2).pow(size - 1)
-        def rec(i: BigInt): Stream[BigInt] = 
+        def rec(i: BigInt): Stream[BigInt] =
           if (i <= count) Stream.cons(i, Stream.cons(-i - 1, rec(i + 1)))
           else Stream.empty
         rec(0) map (BVLiteral(_, size))
@@ -945,7 +946,7 @@ trait SymbolOps { self: TypeOps =>
     var assumptions: Seq[Expr] = Seq.empty
 
     val newExpr = transformWithPC(expr)((e, env, op) => e match {
-      case Assume(pred, body) if (variablesOf(pred) ++ env.variables) subsetOf vars =>
+      case Assume(pred, body) if (variablesOf(pred) ++ env.freeVariables) subsetOf vars =>
         assumptions :+= env implies pred
         op.rec(body, env withCond pred)
       case _ => op.superRec(e, env)
@@ -1053,6 +1054,7 @@ trait SymbolOps { self: TypeOps =>
             nl
 
           case fi: FunctionInvocation =>
+            // FIXME should this also use "open" bounds?
             val problematic = utils.fixpoint((vs: Set[Variable]) => vs ++ path.bindings.collect {
               case (vd, e) if (variablesOf(e) & vs).nonEmpty => vd.toVariable
               case (vd, e) if exists { case fi: FunctionInvocation => true case _ => false }(e) => vd.toVariable
@@ -1073,7 +1075,7 @@ trait SymbolOps { self: TypeOps =>
 
       def replace(path: Path, oldE: Expr, newE: Expr, body: Expr): Expr = transformWithPC(body) {
         (e, env, op) =>
-          if ((path.bindings.toSet subsetOf env.bindings.toSet) &&
+          if ((path.bindings.toSet subsetOf env.bindings.toSet) && // FIXME bindings or bounds?
             (path.conditions == env.conditions) && e == oldE) {
             newE
           } else {

--- a/src/main/scala/inox/ast/SymbolOps.scala
+++ b/src/main/scala/inox/ast/SymbolOps.scala
@@ -1054,7 +1054,6 @@ trait SymbolOps { self: TypeOps =>
             nl
 
           case fi: FunctionInvocation =>
-            // FIXME should this also use "open" bounds?
             val problematic = utils.fixpoint((vs: Set[Variable]) => vs ++ path.bindings.collect {
               case (vd, e) if (variablesOf(e) & vs).nonEmpty => vd.toVariable
               case (vd, e) if exists { case fi: FunctionInvocation => true case _ => false }(e) => vd.toVariable
@@ -1075,8 +1074,9 @@ trait SymbolOps { self: TypeOps =>
 
       def replace(path: Path, oldE: Expr, newE: Expr, body: Expr): Expr = transformWithPC(body) {
         (e, env, op) =>
-          if ((path.bindings.toSet subsetOf env.bindings.toSet) && // FIXME bindings or bounds?
-            (path.conditions == env.conditions) && e == oldE) {
+          if ((path.bindings.toSet subsetOf env.bindings.toSet) &&
+              (path.bounds.toSet subsetOf env.bounds.toSet) &&
+              (path.conditions == env.conditions) && e == oldE) {
             newE
           } else {
             op.superRec(e, env)

--- a/src/main/scala/inox/tip/Parser.scala
+++ b/src/main/scala/inox/tip/Parser.scala
@@ -142,10 +142,13 @@ class Parser(file: File) {
       (Some(tpsLocals.extractTerm(term)), locals)
 
     case DeclareConst(sym, sort) =>
-      (None, locals.withVariable(sym, Variable.fresh(sym.name, locals.extractSort(sort)).setPos(sym.optPos)))
+      (None, locals.withVariable(sym,
+        Variable.fresh(sym.name, locals.extractSort(sort)).setPos(sym.optPos)))
 
     case DeclareConstPar(tps, sym, sort) =>
-      extractCommand(DeclareFunPar(tps, sym, Seq.empty, sort))
+      val tpsLocals = locals.withGenerics(tps.map(s => s -> TypeParameter.fresh(s.name).setPos(s.optPos)))
+      (None, locals.withVariable(sym,
+        Variable.fresh(sym.name, tpsLocals.extractSort(sort)).setPos(sym.optPos)))
 
     case DeclareFun(name, sorts, returnSort) =>
       (None, locals.withFunction(name, extractSignature(FunDec(name, sorts.map {

--- a/src/main/scala/inox/tip/Parser.scala
+++ b/src/main/scala/inox/tip/Parser.scala
@@ -142,7 +142,7 @@ class Parser(file: File) {
       (Some(tpsLocals.extractTerm(term)), locals)
 
     case DeclareConst(sym, sort) =>
-      extractCommand(DeclareFun(sym, Seq.empty, sort))
+      (None, locals.withVariable(sym, Variable.fresh(sym.name, locals.extractSort(sort)).setPos(sym.optPos)))
 
     case DeclareConstPar(tps, sym, sort) =>
       extractCommand(DeclareFunPar(tps, sym, Seq.empty, sort))

--- a/src/main/scala/inox/tip/Parser.scala
+++ b/src/main/scala/inox/tip/Parser.scala
@@ -142,13 +142,22 @@ class Parser(file: File) {
       (Some(tpsLocals.extractTerm(term)), locals)
 
     case DeclareConst(sym, sort) =>
-      (None, locals.withVariable(sym,
-        Variable.fresh(sym.name, locals.extractSort(sort)).setPos(sym.optPos)))
+      val choose = Choose(
+        ValDef(FreshIdentifier(sym.name), locals.extractSort(sort)),
+        BooleanLiteral(true)
+      ).setPos(sym.optPos)
+      (None, locals.withVariable(sym, choose))
 
     case DeclareConstPar(tps, sym, sort) =>
       val tpsLocals = locals.withGenerics(tps.map(s => s -> TypeParameter.fresh(s.name).setPos(s.optPos)))
-      (None, locals.withVariable(sym,
-        Variable.fresh(sym.name, tpsLocals.extractSort(sort)).setPos(sym.optPos)))
+      val choose = Choose(
+        ValDef(FreshIdentifier(sym.name), tpsLocals.extractSort(sort)),
+        BooleanLiteral(true)
+      ).setPos(sym.optPos)
+      (None, locals.withVariable(sym, choose)) // FIXME This failes:
+// [info] -  77: UNSAT - MergeSort2.scala-0.tip solver=smt-z3 assumechecked *** FAILED *** (128 milliseconds)
+// [info]   java.lang.ClassCastException: inox.ast.Expressions$Choose cannot be cast to inox.ast.Expressions$Variable
+
 
     case DeclareFun(name, sorts, returnSort) =>
       (None, locals.withFunction(name, extractSignature(FunDec(name, sorts.map {

--- a/src/main/scala/inox/tip/Parser.scala
+++ b/src/main/scala/inox/tip/Parser.scala
@@ -142,22 +142,10 @@ class Parser(file: File) {
       (Some(tpsLocals.extractTerm(term)), locals)
 
     case DeclareConst(sym, sort) =>
-      val choose = Choose(
-        ValDef(FreshIdentifier(sym.name), locals.extractSort(sort)),
-        BooleanLiteral(true)
-      ).setPos(sym.optPos)
-      (None, locals.withVariable(sym, choose))
+      extractCommand(DeclareFun(sym, Seq.empty, sort))
 
     case DeclareConstPar(tps, sym, sort) =>
-      val tpsLocals = locals.withGenerics(tps.map(s => s -> TypeParameter.fresh(s.name).setPos(s.optPos)))
-      val choose = Choose(
-        ValDef(FreshIdentifier(sym.name), tpsLocals.extractSort(sort)),
-        BooleanLiteral(true)
-      ).setPos(sym.optPos)
-      (None, locals.withVariable(sym, choose)) // FIXME This failes:
-// [info] -  77: UNSAT - MergeSort2.scala-0.tip solver=smt-z3 assumechecked *** FAILED *** (128 milliseconds)
-// [info]   java.lang.ClassCastException: inox.ast.Expressions$Choose cannot be cast to inox.ast.Expressions$Variable
-
+      extractCommand(DeclareFunPar(tps, sym, Seq.empty, sort))
 
     case DeclareFun(name, sorts, returnSort) =>
       (None, locals.withFunction(name, extractSignature(FunDec(name, sorts.map {
@@ -168,7 +156,7 @@ class Parser(file: File) {
       val tpsLocals = locals.withGenerics(tps.map(s => s -> TypeParameter.fresh(s.name).setPos(s.optPos)))
       (None, locals.withFunction(name, extractSignature(FunDec(name, sorts.map {
         sort => SortedVar(SSymbol(FreshIdentifier("x").uniqueName).setPos(sort), sort).setPos(sort)
-      }, returnSort), tps)))
+      }, returnSort), tps)(tpsLocals)))
 
     case DefineFun(funDef) =>
       val fd = extractFunction(funDef, Seq.empty)

--- a/src/main/scala/inox/transformers/SimplifierWithPC.scala
+++ b/src/main/scala/inox/transformers/SimplifierWithPC.scala
@@ -105,7 +105,7 @@ trait SimplifierWithPC extends TransformerWithPC { self =>
       })
     })
 
-    def withBinding(p: (ValDef, Expr)) = {
+    override def withBinding(p: (ValDef, Expr)) = {
       val (vd, expr) = p
       if (formulaSize(expr) > 20) {
         this
@@ -132,7 +132,9 @@ trait SimplifierWithPC extends TransformerWithPC { self =>
       }
     }
 
-    def withCond(e: Expr) = if (formulaSize(e) > 20) this else {
+    override def withBound(b: ValDef) = ???
+
+    override def withCond(e: Expr) = if (formulaSize(e) > 20) this else {
       val clauses = getClauses(e)
       val clauseSet = clauses.toSet
       val newConditions = conditions.flatMap { case clause @ TopLevelOrs(es) =>
@@ -145,7 +147,7 @@ trait SimplifierWithPC extends TransformerWithPC { self =>
       new CNFPath(exprSubst, boolSubst, conds, cnfCache, simpCache)
     }
 
-    def merge(that: CNFPath) = new CNFPath(
+    override def merge(that: CNFPath) = new CNFPath(
       exprSubst.clone ++= that.exprSubst,
       boolSubst ++ that.boolSubst,
       conditions ++ that.conditions,
@@ -153,7 +155,7 @@ trait SimplifierWithPC extends TransformerWithPC { self =>
       simpCache ++= that.simpCache
     )
 
-    def negate = new CNFPath(exprSubst, boolSubst, Set(), cnfCache, simpCache) withConds conditions.map(not)
+    override def negate = new CNFPath(exprSubst, boolSubst, Set(), cnfCache, simpCache) withConds conditions.map(not)
 
     override def toString = conditions.toString
   }

--- a/src/main/scala/inox/transformers/SimplifierWithPC.scala
+++ b/src/main/scala/inox/transformers/SimplifierWithPC.scala
@@ -163,8 +163,9 @@ trait SimplifierWithPC extends TransformerWithPC { self =>
   implicit object CNFPath extends PathProvider[CNFPath] {
     def empty = new CNFPath(new Bijection[Variable, Expr], Map.empty, Set.empty, MutableMap.empty, MutableMap.empty)
     def apply(path: Path) = path.elements.foldLeft(empty) {
-      case (path, Left(p)) => path withBinding (p._1 -> transform(p._2, path))
-      case (path, Right(c)) => path withCond (transform(c, path))
+      case (path, Path.CloseBound(vd, e)) => path withBinding (vd -> transform(e, path))
+      case (path, Path.OpenBound(_)) => path // NOTE CNFPath doesn't need to track such bounds.
+      case (path, Path.Condition(c)) => path withCond transform(c, path)
     }
   }
 

--- a/src/main/scala/inox/transformers/SimplifierWithPC.scala
+++ b/src/main/scala/inox/transformers/SimplifierWithPC.scala
@@ -132,7 +132,7 @@ trait SimplifierWithPC extends TransformerWithPC { self =>
       }
     }
 
-    override def withBound(b: ValDef) = ???
+    override def withBound(b: ValDef) = this // NOTE CNFPath doesn't need to track such bounds.
 
     override def withCond(e: Expr) = if (formulaSize(e) > 20) this else {
       val clauses = getClauses(e)

--- a/src/main/scala/inox/transformers/TransformerWithPC.scala
+++ b/src/main/scala/inox/transformers/TransformerWithPC.scala
@@ -17,6 +17,18 @@ trait TransformerWithPC extends Transformer {
       val sb = rec(b, env withBinding (i -> se))
       Let(i, se, sb).copiedFrom(e)
 
+    case Lambda(args, b) =>
+      val sb = rec(b, env withBounds args)
+      Lambda(args, sb).copiedFrom(e)
+
+    case Forall(args, b) =>
+      val sb = rec(b, env withBounds args)
+      Forall(args, sb).copiedFrom(e)
+
+    case Choose(arg, p) =>
+      val sp = rec(p, env withBound arg)
+      Choose(arg, sp).copiedFrom(e)
+
     case Assume(pred, body) =>
       val sp = rec(pred, env)
       val sb = rec(body, env withCond sp)


### PR DESCRIPTION
This catches error such as this one, but hopefully many more:

```scala
  case class B(var x: Int) {
    def foo(y: Int): Boolean = {
      x == y // just a dummy example
    } ensuring { res =>
      old(x) == x // instead of old(this).x == x
    }
  }
```

Of course, we need to give the user a proper error message, but that's the job of stainless. This patch ensures all transformations don't mess (too much) with variables.

**BUT** there's a catch...

The TIP parser doesn't extract commands such as `(declare-const |error: Match is non-exhaustive!58| (_ BitVec 32))` into `Let` statement and the "variable" (`Parser.Locals.vars`) are not present in the `Symbols`, hence the tests are currently failing.

The question is, how do we workaround that? Should the TIP part be updated to use `Let`? (I've no idea how it works nor how much effort it would mean.) Should this kind of checks be disabled for some part of Inox? Should they be moved to stainless? 

