### PR TITLE
Extend Reporter to report internal exceptions

### DIFF
--- a/src/main/scala/inox/Reporter.scala
+++ b/src/main/scala/inox/Reporter.scala
@@ -111,8 +111,10 @@ abstract class Reporter(val debugSections: Set[DebugSection]) {
     whenDebug(NoPosition, section)(body)
 
   final def debug(pos: Position, msg: => Any, e: Throwable)(implicit section: DebugSection): Unit = {
-    debug(pos, msg)
-    logTrace(DEBUG(section), e)
+    if (isDebugEnabled(section)) {
+      debug(pos, msg)
+      logTrace(DEBUG(section), e)
+    }
   }
 
   final def debug(e: Throwable)(implicit section: DebugSection): Unit =

--- a/src/main/scala/inox/Reporter.scala
+++ b/src/main/scala/inox/Reporter.scala
@@ -115,6 +115,9 @@ abstract class Reporter(val debugSections: Set[DebugSection]) {
     logTrace(DEBUG(section), e)
   }
 
+  final def debug(e: Throwable)(implicit section: DebugSection): Unit =
+    debug(NoPosition, e.getMessage, e)
+
   private def logTrace(severity: Severity, e: Throwable): Unit = {
     var indent = 0
     def log(msg: Any) = emit(account(Message(severity, NoPosition, ("  " * indent) + msg)))

--- a/src/main/scala/inox/Reporter.scala
+++ b/src/main/scala/inox/Reporter.scala
@@ -121,7 +121,7 @@ abstract class Reporter(val debugSections: Set[DebugSection]) {
   final def debug(e: Throwable)(implicit section: DebugSection): Unit =
     debug(NoPosition, e.getMessage, e)
 
-  private def logTrace(severity: Severity, e: Throwable): Unit = {
+  private def logTrace(severity: Severity, e: Throwable): Unit = synchronized {
     var indent = 0
     def log(msg: Any) = emit(account(Message(severity, NoPosition, ("  " * indent) + msg)))
 
@@ -165,7 +165,7 @@ class DefaultReporter(debugSections: Set[DebugSection]) extends Reporter(debugSe
     }
   }
 
-  def emit(msg: Message) = {
+  def emit(msg: Message) = synchronized {
     println(reline(severityToPrefix(msg.severity), smartPos(msg.position) + msg.msg.toString))
     printLineContent(msg.position)
   }

--- a/src/main/scala/inox/Reporter.scala
+++ b/src/main/scala/inox/Reporter.scala
@@ -93,6 +93,7 @@ abstract class Reporter(val debugSections: Set[DebugSection]) {
   final def info(msg: Any): Unit          = info(NoPosition, msg)
   final def warning(msg: Any): Unit       = warning(NoPosition, msg)
   final def error(msg: Any): Unit         = error(NoPosition, msg)
+  final def error(e: Throwable): Unit     = logTrace(ERROR, e)
   final def title(msg: Any): Unit         = title(NoPosition, msg)
   final def fatalError(msg: Any): Nothing = fatalError(NoPosition, msg)
 


### PR DESCRIPTION
This is a minor addition to report exceptions' trace. For example, it should print a more detailed error message for epfl-lara/stainless#141 (no changes to stainless required).