### PR TITLE
Allow equality symbol in the options

### DIFF
--- a/src/main/scala/inox/Options.scala
+++ b/src/main/scala/inox/Options.scala
@@ -113,7 +113,7 @@ object OptionParsers {
 
 object OptionsHelpers {
 
-  private val matcher = s"--(.*)=(.*)".r
+  private val matcher = s"--(.*?)=(.*)".r
   private val matcherWithout = s"--(.*)".r
 
   def nameValue(s: String) = s match {


### PR DESCRIPTION
This changes makes it possible to write `--debug-objects=x_=` in Stainless to debug setters.