### PR TITLE
BVTypeExtractor should not be sealed

### DIFF
--- a/src/main/scala/inox/ast/Constructors.scala
+++ b/src/main/scala/inox/ast/Constructors.scala
@@ -20,11 +20,7 @@ trait Constructors { self: Trees =>
   def tupleWrap(es: Seq[Expr]): Expr = es match {
     case Seq() => UnitLiteral()
     case Seq(elem) => elem
-    case more =>
-      more.zipWithIndex.collect { case (TupleSelect(e, idx), i) if idx == i + 1 => e } match {
-        case ls @ (e +: es) if ls.size == more.size && es.forall(_ == e) => e
-        case _ => Tuple(more)
-      }
+    case more => Tuple(more)
   }
 
   /** Wraps the sequence of types as a tuple. If the sequence contains a single type, it is returned instead.

--- a/src/main/scala/inox/ast/Types.scala
+++ b/src/main/scala/inox/ast/Types.scala
@@ -66,7 +66,7 @@ trait Types { self: Trees =>
 
   sealed case class BVType(signed: Boolean, size: Int) extends Type
 
-  sealed abstract class BVTypeExtractor(signed: Boolean, size: Int) {
+  abstract class BVTypeExtractor(signed: Boolean, size: Int) {
     def apply(): BVType = BVType(signed, size)
     def unapply(tpe: BVType): Boolean = tpe.signed == signed && tpe.size == size
   }


### PR DESCRIPTION
Other projects may want to create extractors for unsigned bitvector types, so it seems this class should be extensible