### PR TITLE
Replace uses of scala.collection.mutable.HashMap#getOrElseUpdate with getOrElse + manual update

### DIFF
--- a/src/main/scala/inox/ast/ExprOps.scala
+++ b/src/main/scala/inox/ast/ExprOps.scala
@@ -74,8 +74,10 @@ trait ExprOps extends GenTreeOps {
     variablesOf(expr).foreach(v => subst(v) = v)
 
     new SelfTreeTransformer {
-      override def transform(vd: ValDef): ValDef = subst.getOrElseUpdate(vd.toVariable, {
-        super.transform(vd).freshen.toVariable
+      override def transform(vd: ValDef): ValDef = subst.getOrElse(vd.toVariable, {
+        val res = super.transform(vd).freshen.toVariable
+        subst(vd.toVariable) = res
+        res
       }).toVal
 
       override def transform(expr: Expr): Expr = expr match {

--- a/src/main/scala/inox/ast/SymbolOps.scala
+++ b/src/main/scala/inox/ast/SymbolOps.scala
@@ -41,7 +41,11 @@ trait SymbolOps { self: TypeOps =>
 
   private var simplifierCache: MutableMap[PurityOptions, SimplifierWithPC] = MutableMap.empty
   def simplifier(implicit purityOpts: PurityOptions): SimplifierWithPC = synchronized {
-    simplifierCache.getOrElseUpdate(purityOpts, simplifierWithPC(purityOpts))
+    simplifierCache.getOrElse(purityOpts, {
+      val res = simplifierWithPC(purityOpts)
+      simplifierCache(purityOpts) = res
+      res
+    })
   }
 
   def simplifyExpr(expr: Expr)(implicit opts: PurityOptions): Expr = simplifyIn(expr, Path.empty)

--- a/src/main/scala/inox/solvers/princess/AbstractPrincessSolver.scala
+++ b/src/main/scala/inox/solvers/princess/AbstractPrincessSolver.scala
@@ -458,14 +458,16 @@ trait AbstractPrincessSolver extends AbstractSolver with ADTManagers {
           ctx.model.eval(iterm).map { ideal =>
             val n = BigInt(ideal.bigIntValue)
             if (ctx.seen(n)) {
-              ctx.chooses.getOrElseUpdate(n, {
-                Choose(Variable.fresh("x", ft, true).toVal, BooleanLiteral(true))
+              ctx.chooses.getOrElse(n, {
+                val res = Choose(Variable.fresh("x", ft, true).toVal, BooleanLiteral(true))
+                ctx.chooses(n) = res
+                res
               })
             } else {
-              ctx.lambdas.getOrElseUpdate(n, {
+              ctx.lambdas.getOrElse(n, {
                 val newCtx = ctx.withSeen(n)
                 val params = ft.from.map(tpe => ValDef.fresh("x", tpe, true))
-                uniquateClosure(n.intValue, lambdas.getB(ft)
+                val res = uniquateClosure(n.intValue, lambdas.getB(ft)
                   .flatMap { fun =>
                     val interps = ctx.model.interpretation.flatMap {
                       case (SimpleAPI.IntFunctionLoc(`fun`, ptr +: args), SimpleAPI.IntValue(res)) =>
@@ -496,6 +498,8 @@ trait AbstractPrincessSolver extends AbstractSolver with ADTManagers {
                     case _: NoSimpleValue =>
                       Lambda(params, Choose(ValDef.fresh("res", ft.to), BooleanLiteral(true)))
                   }))
+                  ctx.lambdas(n) = res
+                  res
               })
             }
           }

--- a/src/main/scala/inox/tip/Printer.scala
+++ b/src/main/scala/inox/tip/Printer.scala
@@ -127,8 +127,10 @@ class Printer(val program: InoxProgram, val context: Context, writer: Writer) ex
       Sort(id, tpSorts)
 
     case TupleType(ts) =>
-      val tpe = tuples.getOrElseUpdate(ts.size, {
-        TupleType(List.range(0, ts.size).map(i => TypeParameter.fresh("A" + i)))
+      val tpe = tuples.getOrElse(ts.size, {
+        val res = TupleType(List.range(0, ts.size).map(i => TypeParameter.fresh("A" + i)))
+        tuples(ts.size) = res
+        res
       })
       adtManager.declareADTs(tpe, declareDatatypes)
       val tpSorts = ts.map(declareSort)

--- a/src/main/scala/inox/utils/Timer.scala
+++ b/src/main/scala/inox/utils/Timer.scala
@@ -68,11 +68,7 @@ final class TimerStorage private(val _name: Option[String])
   def selectDynamic(name: String): TimerStorage = get(name)
 
   def get(name: String): TimerStorage = synchronized {
-    db.getOrElse(name, {
-      val res = new TimerStorage(Some(name))
-      db(name) = res
-      res
-    })
+    db.getOrElseUpdate(name, new TimerStorage(Some(name)))
   }
 
   /**

--- a/src/main/scala/inox/utils/Timer.scala
+++ b/src/main/scala/inox/utils/Timer.scala
@@ -68,7 +68,11 @@ final class TimerStorage private(val _name: Option[String])
   def selectDynamic(name: String): TimerStorage = get(name)
 
   def get(name: String): TimerStorage = synchronized {
-    db.getOrElseUpdate(name, new TimerStorage(Some(name)))
+    db.getOrElse(name, {
+      val res = new TimerStorage(Some(name))
+      db(name) = res
+      res
+    })
   }
 
   /**


### PR DESCRIPTION
The issue is due to `scala.collection.mutable.HashMap#getOrElseUpdate` being broken[1, 2] in Scala v2.11.9 - v2.12.7.

This sometimes resulted in ill-formed code, such as in the following example surfaced in epfl-lara/stainless#433:

BEFORE FRESHENING:

    val A$103: (Object$0) => Boolean = (x$186: Object$0) => x$186 is Integer$0
    val thiss$7: { x$245: Object$0 | @unchecked isMonoid$0(x$245, A$103) } = thiss$12
    val x$178: { x$247: Object$0 | @unchecked A$103(x$247) } = Integer$0(x$180)
    val y$17: { x$248: Object$0 | @unchecked A$103(x$248) } = Integer$0(y$19)
    val z$10: { x$249: Object$0 | @unchecked A$103(x$249) } = Integer$0(z$12)
    @unchecked (append$2(A$103, thiss$7, x$178, append$2(A$103, thiss$7, y$17, z$10)) == append$2(A$103, thiss$7, append$2(A$103, thiss$7, x$178, y$17), z$10))

AFTER FRESHENING:

    val A$108: (Object$0) => Boolean = (x$345: Object$0) => x$345 is Integer$0
    val thiss$13: { x$346: Object$0 | @unchecked isMonoid$0(x$346, A$108) } = thiss$12
    val x$348: { x$347: Object$0 | @unchecked A$108(x$347) } = Integer$0(x$180)
    val y$22: { x$349: Object$0 | @unchecked A$108(x$349) } = Integer$0(y$19)
    val z$14: { x$350: Object$0 | @unchecked A$108(x$350) } = Integer$0(z$12)
    @unchecked (append$2(A$108, thiss$13, x$348, append$2(A$108, thiss$13, y$22, z$15)) == append$2(A$108, thiss$13, append$2(A$108, thiss$13, x$348, y$22), z$15))

Note that `z$10` has been freshened twice above: once to `z$14`, and then again to `z$15`.

- [1] scala/bug#10703
- [2] retronym/scala@5af85b5
