### PR TITLE
Respect PrinterOptions when throwing a TypeErrorException

### DIFF
--- a/src/main/scala/inox/utils/Lazy.scala
+++ b/src/main/scala/inox/utils/Lazy.scala
@@ -4,8 +4,26 @@ package inox
 package utils
 
 /** Class that provides deadlock-free lazyness */
+class Lazy1[S, T](computeValue: S => T) {
+  @volatile
+  private[this] var computed: Map[S, T] = Map.empty
+
+  def get(s: S): T = {
+    if (!computed.contains(s)) {
+      computed = computed.updated(s, computeValue(s))
+    }
+    computed(s)
+  }
+}
+
+object Lazy1 {
+  def apply[T, S](f: T => S): Lazy1[T, S] = new Lazy1(f)
+}
+
 class Lazy[T](computeValue: => T) {
-  @volatile private[this] var computed: Boolean = false
+  @volatile
+  private[this] var computed: Boolean = false
+
   private[this] var value: T = _
 
   def get: T = {
@@ -20,3 +38,4 @@ class Lazy[T](computeValue: => T) {
 object Lazy {
   def apply[T](b: => T): Lazy[T] = new Lazy(b)
 }
+


### PR DESCRIPTION
Make it easier to debug some type errors, eg. when we get `expected 'Type', found 'Type'`.