### PR TITLE
Consider all non-obvious choose's to be impure

### DIFF
--- a/src/main/scala/inox/transformers/SimplifierWithPC.scala
+++ b/src/main/scala/inox/transformers/SimplifierWithPC.scala
@@ -94,7 +94,7 @@ trait SimplifierWithPC extends Transformer { self =>
     case e if path implies not(e) => (BooleanLiteral(false).copiedFrom(e), true)
 
     case c @ Choose(res, BooleanLiteral(true)) if hasInstance(res.tpe) == Some(true) => (c, true)
-    case c: Choose => (c, opts.assumeChecked)
+    case c: Choose => (c, false)
 
     case Lambda(params, body) =>
       val (rb, _) = simplify(body, path withBounds params)


### PR DESCRIPTION
Temporary fix for https://github.com/epfl-lara/stainless/issues/483

I couldn't use `Ensure` in the `InoxEncoder` because it's not an Inox tree, is that fix ok?