### PR TITLE
Parsing and extraction for lambdas in Z3's (4.8.4) model output

### DIFF
--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -91,7 +91,7 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
   protected val extSym = SSymbol("_")
 
   protected lazy val setSort: SSymbol = {
-    val s = SSymbol("Set")
+    val s = SSymbol("InoxSet")
     val t = SSymbol("T")
 
     val arraySort = Sort(

--- a/src/main/scala/inox/transformers/SimplifierWithPC.scala
+++ b/src/main/scala/inox/transformers/SimplifierWithPC.scala
@@ -94,7 +94,7 @@ trait SimplifierWithPC extends Transformer { self =>
     case e if path implies not(e) => (BooleanLiteral(false).copiedFrom(e), true)
 
     case c @ Choose(res, BooleanLiteral(true)) if hasInstance(res.tpe) == Some(true) => (c, true)
-    case c: Choose => (c, opts.assumeChecked)
+    case c: Choose => (c, false)
 
     case Lambda(params, body) =>
       val (rb, _) = simplify(body, path withBounds params)


### PR DESCRIPTION
Z3 4.8.4 returns lambdas which can be parsed using `smtlib.extensions.tip`. These can then be extracted into maps, sets and bags similarly to the `as-array` cases.