### PR TITLE
Move implicit debug section higher

### DIFF
--- a/src/main/scala/inox/solvers/unrolling/Templates.scala
+++ b/src/main/scala/inox/solvers/unrolling/Templates.scala
@@ -26,6 +26,8 @@ trait Templates
   import program.trees._
   import program.symbols._
 
+  implicit val debugSection = DebugSectionSolver
+
   type Encoded
 
   def asString(e: Encoded): String
@@ -205,8 +207,6 @@ trait Templates
 
     promoted
   }
-
-  implicit val debugSection = DebugSectionSolver
 
   type Arg = Either[Encoded, Matcher]
 


### PR DESCRIPTION
I sometimes have this error when compiling Inox from Stainless (this PR fixes it)

```
inox/src/main/scala/inox/solvers/unrolling/Templates.scala:79:19: could not find implicit value for parameter section: inox.DebugSection
[error]     reporter.debug("Unrolling generation [" + currentGen + "]")
```