### PR TITLE
Fix the extraction of finite maps from Z3

### DIFF
--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -148,6 +148,8 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
         val Some(Lambda(Seq(arg), body)) = context.getFunction(k, FunctionType(Seq(keyType), valueType))
 
         def extractCases(e: Expr): FiniteMap = e match {
+          case Equals(argV, k) if valueType == BooleanType() && argV == arg.toVariable =>
+            FiniteMap(Seq((k, BooleanLiteral(true))), BooleanLiteral(false), keyType, valueType)
           case IfExpr(Equals(argV, k), v, e) if argV == arg.toVariable =>
             val FiniteMap(elems, default, from, to) = extractCases(e)
             FiniteMap(elems :+ (k, v), default, from, to)
@@ -170,6 +172,8 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
         val body = fromSMT(term)(context.withVariables(Seq(s -> arg.toVariable)))
 
         def extractCases(e: Expr): FiniteMap = e match {
+          case Equals(argV, k) if valueType == BooleanType() && argV == arg.toVariable =>
+            FiniteMap(Seq((k, BooleanLiteral(true))), BooleanLiteral(false), keyType, valueType)
           case IfExpr(Equals(argV, k), v, e) if argV == arg.toVariable =>
             val FiniteMap(elems, default, from, to) = extractCases(e)
             FiniteMap(elems :+ (k, v), default, from, to)

--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -169,7 +169,7 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
 
       case (SMTLambda(Seq(SortedVar(s, sort)), term), Some(tpe @ MapType(keyType, valueType))) =>
         val arg = ValDef.fresh(s.name, fromSMT(sort))
-        val body = fromSMT(term)(context.withVariables(Seq(s -> arg.toVariable)))
+        val body = fromSMT(term, Some(valueType))(context.withVariables(Seq(s -> arg.toVariable)))
 
         def extractCases(e: Expr): FiniteMap = e match {
           case Equals(argV, k) if valueType == BooleanType() && argV == arg.toVariable =>

--- a/src/test/scala/inox/solvers/SemanticsSuite.scala
+++ b/src/test/scala/inox/solvers/SemanticsSuite.scala
@@ -534,6 +534,16 @@ class SemanticsSuite extends FunSuite {
     )) contains true)
   }
 
+  test("Z3 Set Extraction", filterSolvers(_, princess = true, cvc4 = true)) { ctx =>
+    val s = solver(ctx)
+
+    // Singleton set inside of a map is translated to (lambda ((x Int)) (= x 0))
+    check(s,
+      FiniteMap(Seq(), FiniteSet(Seq(IntegerLiteral(0)), IntegerType()), IntegerType(), SetType(IntegerType())),
+      FiniteMap(Seq(), FiniteSet(Seq(IntegerLiteral(0)), IntegerType()), IntegerType(), SetType(IntegerType()))
+    )
+  }
+
   test("Simple Bag Operations", filterSolvers(_, princess = true)) { ctx =>
     val s = solver(ctx)
 


### PR DESCRIPTION
This PR fixes a special case where finite maps are not correctly extracted. This happens for the special case where the value type of the map is `BooleanType`. Z3 sometimes represents those in that form: `(lambda ((x KeyType)) (= x someKey))`. That should be extracted as a finite map where `someKey` maps to `true` and the rest to `false`.

That case is currently not handled and I encountered a case where the output from stainless was misleading because of that extraction problem.