### PR TITLE
Add MapMerge construct

### DIFF
--- a/src/it/scala/inox/solvers/unrolling/MapMergeSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/MapMergeSuite.scala
@@ -1,0 +1,66 @@
+/* Copyright 2009-2020 EPFL, Lausanne */
+
+package inox
+package solvers
+package unrolling
+
+class MapMergeSuite extends SolvingTestSuite with DatastructureUtils {
+  import trees._
+  import dsl._
+
+  override def configurations = for {
+    solverName   <- Seq("nativez3", "unrollz3", "smt-z3")
+    feelingLucky <- Seq(false, true)
+  } yield Seq(
+    optSelectedSolvers(Set(solverName)),
+    optCheckModels(true),
+    optFeelingLucky(feelingLucky),
+    optTimeout(300),
+    ast.optPrintUniqueIds(true)
+  )
+
+  override def optionsString(options: Options): String = {
+    "solvr=" + options.findOptionOrDefault(optSelectedSolvers).head + " " +
+    "lucky=" + options.findOptionOrDefault(optFeelingLucky)
+  }
+
+  val keyT = TypeParameter.fresh("K")
+  val valueT = TypeParameter.fresh("V")
+
+  val mask = ("mask" :: SetType(keyT)).toVariable
+  val map1 = ("map1" :: MapType(keyT, valueT)).toVariable
+  val map2 = ("map2" :: MapType(keyT, valueT)).toVariable
+  val merged = MapMerge(mask, map1, map2)
+  val dummyValue = ("dummyValue" :: valueT).toVariable
+  val someKey = ("someKey" :: keyT).toVariable
+
+  val symbols = baseSymbols
+  val program = InoxProgram(symbols)
+
+  test("Finite model finding 1") { implicit ctx =>
+    val clause = Not(Equals(merged, FiniteMap(Seq.empty, dummyValue, keyT, valueT)))
+    assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
+  }
+
+  test("Finite model finding 2") { implicit ctx =>
+    val clause = Not(Equals(merged, map1))
+    assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
+  }
+
+  test("Finite model finding 3") { implicit ctx =>
+    val clause = Not(Equals(merged, map2))
+    assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
+  }
+
+  test("Empty mask") { implicit ctx =>
+    val clause = Implies(Equals(mask, FiniteSet(Seq.empty, keyT)), Equals(merged, map2))
+    assert(SimpleSolverAPI(program.getSolver).solveVALID(clause) contains true)
+  }
+
+  test("Element in mask") { implicit ctx =>
+    val clause = Implies(
+      ElementOfSet(someKey, mask),
+      Equals(MapApply(merged, someKey), MapApply(map1, someKey)))
+    assert(SimpleSolverAPI(program.getSolver).solveVALID(clause) contains true)
+  }
+}

--- a/src/main/scala/inox/ast/Deconstructors.scala
+++ b/src/main/scala/inox/ast/Deconstructors.scala
@@ -395,6 +395,11 @@ trait TreeDeconstructor {
       val s.MapUpdated(map, k, v) = expr
       (NoIdentifiers, NoVariables, Seq(map, k, v), NoTypes, NoFlags,
         (_, _, es, _, _) => t.MapUpdated(es(0), es(1), es(2)))
+    },
+    classOf[s.MapMerge] -> { expr =>
+      val s.MapMerge(mask, map1, map2) = expr
+      (NoIdentifiers, NoVariables, Seq(mask, map1, map2), NoTypes, NoFlags,
+        (_, _, es, _, _) => t.MapMerge(es(0), es(1), es(2)))
     }
   )
 

--- a/src/main/scala/inox/ast/Expressions.scala
+++ b/src/main/scala/inox/ast/Expressions.scala
@@ -709,4 +709,16 @@ trait Expressions { self: Trees =>
       case _ => Untyped
     }
   }
+
+  /**
+   * Special operation that merges two maps using a set.
+   * The resulting map is a map that contains the key-value pairs of map1 for all keys that are in the mask,
+   * and the key-value pairs of map2 for all keys that are not in the mask.
+   */
+  case class MapMerge(mask: Expr, map1: Expr, map2: Expr) extends Expr with CachingTyped {
+    override protected def computeType(implicit s: Symbols): Type = (getMapType(map1, map2), getSetType(mask)) match {
+      case (mt @ MapType(from, to), SetType(mask)) => checkParamType(mask, from, mt)
+      case _ => Untyped
+    }
+  }
 }

--- a/src/main/scala/inox/ast/Printers.scala
+++ b/src/main/scala/inox/ast/Printers.scala
@@ -284,6 +284,7 @@ trait Printer {
     case MultiplicityInBag(e, b) => p"$b($e)"
     case MapApply(m, k) => p"$m($k)"
     case MapUpdated(m, k, v) => p"$m.updated($k, $v)"
+    case MapMerge(m, m1, m2) => p"internals.mapMerge($m, $m1, $m2)"
 
     case Not(expr) => p"\u00AC$expr"
 

--- a/src/main/scala/inox/ast/Printers.scala
+++ b/src/main/scala/inox/ast/Printers.scala
@@ -284,7 +284,7 @@ trait Printer {
     case MultiplicityInBag(e, b) => p"$b($e)"
     case MapApply(m, k) => p"$m($k)"
     case MapUpdated(m, k, v) => p"$m.updated($k, $v)"
-    case MapMerge(m, m1, m2) => p"internals.mapMerge($m, $m1, $m2)"
+    case MapMerge(mask, m1, m2) => p"$mask.mapMerge($m1, $m2)"
 
     case Not(expr) => p"\u00AC$expr"
 

--- a/src/main/scala/inox/evaluators/RecursiveEvaluator.scala
+++ b/src/main/scala/inox/evaluators/RecursiveEvaluator.scala
@@ -397,6 +397,16 @@ trait RecursiveEvaluator
         case (le,re) => throw EvalError(typeErrorMsg(le, s1.getType))
       }
 
+    case MapMerge(cond, map1, map2) =>
+      (e(cond), e(map1), e(map2)) match {
+        case (FiniteSet(keys, kT), FiniteMap(kvs1, dflt1, _, vT), FiniteMap(kvs2, dflt2, _, _)) =>
+          val fromFstMap = keys.map((_ -> dflt1)).toMap ++ (kvs1.toMap.filterKeys(keys.contains(_)))
+          val fromSndMap = kvs2.toMap -- keys
+          finiteMap((fromFstMap ++ fromSndMap).toSeq, dflt2, kT, vT)
+        case (c, m1, m2) =>
+          throw EvalError(typeErrorMsg(c, cond.getType))
+      }
+
     case ElementOfSet(el,s) => (e(el), e(s)) match {
       case (e, FiniteSet(els, _)) => BooleanLiteral(els.contains(e))
       case (l,r) => throw EvalError(typeErrorMsg(r, SetType(l.getType)))

--- a/src/main/scala/inox/solvers/smtlib/SMTLIBDebugger.scala
+++ b/src/main/scala/inox/solvers/smtlib/SMTLIBDebugger.scala
@@ -22,7 +22,7 @@ trait SMTLIBDebugger extends SMTLIBTarget {
 
   /* Printing VCs */
   protected lazy val debugOut: Option[java.io.FileWriter] = {
-    if (reporter.isDebugEnabled) {
+    if (reporter.isDebugEnabled || true) {
       val file = options.findOptionOrDefault(Main.optFiles).headOption.map(_.getName).getOrElse("NA")
       val n = DebugFileNumbers.next(targetName + file)
       val fileName = s"smt-sessions/$targetName-$file-$n.smt2"

--- a/src/main/scala/inox/solvers/smtlib/SMTLIBDebugger.scala
+++ b/src/main/scala/inox/solvers/smtlib/SMTLIBDebugger.scala
@@ -22,7 +22,7 @@ trait SMTLIBDebugger extends SMTLIBTarget {
 
   /* Printing VCs */
   protected lazy val debugOut: Option[java.io.FileWriter] = {
-    if (reporter.isDebugEnabled || true) {
+    if (reporter.isDebugEnabled) {
       val file = options.findOptionOrDefault(Main.optFiles).headOption.map(_.getName).getOrElse("NA")
       val n = DebugFileNumbers.next(targetName + file)
       val fileName = s"smt-sessions/$targetName-$file-$n.smt2"

--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -314,7 +314,7 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
 
     case MapMerge(mask, map1, map2) =>
       val s = declareSort(map1.getType.asInstanceOf[MapType].to)
-      ArrayMap(SortedSymbol("ite", List(BoolSort(), s), s), toSMT(mask), toSMT(map1), toSMT(map2))
+      ArrayMap(SortedSymbol("ite", List(BoolSort(), s, s), s), toSMT(mask), toSMT(map1), toSMT(map2))
 
     case SetIntersection(l, r) =>
       ArrayMap(SSymbol("and"), toSMT(l), toSMT(r))

--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -262,11 +262,10 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
 
       case (FunctionApplication(
         QualifiedIdentifier(SMTIdentifier(SSymbol("map"),
-          List(SList(List(SSymbol("ite"), SList(List(SSymbol("Bool"), maskT, map1T, map2T)), resT)))), None),
+          List(SList(List(SSymbol("ite"), SList(List(SSymbol("Bool"), _, _, _)), _)))), None),
         Seq(mask, map1, map2)
       ), _) =>
-        // TODO: unify the types maskT, map1T, map2T and resT, because they should all be equal
-        MapMerge(fromSMT(mask, otpe), fromSMT(map1, otpe), fromSMT(map2, otpe))
+        MapMerge(fromSMT(mask), fromSMT(map1), fromSMT(map2))
 
       case _ =>
         super.fromSMT(t, otpe)

--- a/src/main/scala/inox/solvers/theories/MapMergeEncoder.scala
+++ b/src/main/scala/inox/solvers/theories/MapMergeEncoder.scala
@@ -6,44 +6,36 @@ package theories
 
 trait MapMergeEncoder extends SimpleEncoder {
   import trees._
+  import trees.dsl._
 
-  object MapMergeEncoded {
-    def apply(e: MapMerge)(implicit s: Symbols): Expr = {
-      val MapMerge(mask, map1, map2) = e
-      val mapTpe @ MapType(keyTpe, _) = map1.getType
-      val (mapVd, keyVd) = (ValDef.fresh("map", mapTpe), ValDef.fresh("x", keyTpe))
-      val (mapV, keyV) = (mapVd.toVariable, keyVd.toVariable)
-      val cond = Equals(
-        MapApply(mapV, keyV).copiedFrom(e),
-        IfExpr(
-          ElementOfSet(keyV, mask).copiedFrom(e),
-          MapApply(map1, keyV).copiedFrom(e),
-          MapApply(map2, keyV).copiedFrom(e)).copiedFrom(e)).copiedFrom(e)
-      Choose(mapVd, Forall(Seq(keyVd), cond).copiedFrom(e)).copiedFrom(e)
-    }
-
-    def unapply(e: Expr)(implicit s: Symbols): Option[(Expr, Expr, Expr)] =
-      e match {
-        case Choose(mapVd, Forall(Seq(keyVd),
-            Equals(
-              MapApply(mapV1: Variable, keyV1: Variable),
-              IfExpr(
-                ElementOfSet(keyV2: Variable, mask),
-                MapApply(map1, keyV3: Variable),
-                MapApply(map2, keyV4: Variable)))))
-            if keyV1.id == keyVd.id && keyV2.id == keyVd.id &&
-               keyV3.id == keyVd.id && keyV4.id == keyVd.id &&
-               mapV1.id == mapVd.id =>
-          Some((mask, map1, map2))
-        case _ => None
-      }
+  val MapMergeID = FreshIdentifier("mapMerge")
+  val MapMergeFun = mkFunDef(MapMergeID)("K", "V") { case Seq(keyT, valueT) =>
+    val mapTpe = MapType(keyT, valueT)
+    (Seq("mask" :: SetType(keyT), "map1" :: mapTpe, "map2" :: mapTpe), mapTpe, {
+      case Seq(mask, map1, map2) =>
+        choose("map" :: mapTpe) { map =>
+          forall("x" :: keyT) { x =>
+            MapApply(map, x) ===
+            (if_ (ElementOfSet(mask, x)) {
+              MapApply(map1, x)
+            } else_ {
+              MapApply(map2, x)
+            })
+          }
+        }
+    })
   }
+
+  override val extraFunctions = Seq(MapMergeFun)
 
   protected object encoder extends SelfTreeTransformer {
     import sourceProgram._
 
     override def transform(e: Expr): Expr = e match {
-      case e: MapMerge => transform(MapMergeEncoded(e))
+      case MapMerge(mask, map1, map2) =>
+        val MapType(keyTpe, valueTpe) = map1.getType
+        MapMergeFun(transform(keyTpe), transform(valueTpe))(
+          transform(mask), transform(map1), transform(map2)).copiedFrom(e)
       case _ => super.transform(e)
     }
   }
@@ -52,7 +44,7 @@ trait MapMergeEncoder extends SimpleEncoder {
     import targetProgram._
 
     override def transform(e: Expr): Expr = e match {
-      case MapMergeEncoded(mask, map1, map2) =>
+      case FunctionInvocation(MapMergeID, _, Seq(mask, map1, map2)) =>
         MapMerge(transform(mask), transform(map1), transform(map2)).copiedFrom(e)
       case _ => super.transform(e)
     }

--- a/src/main/scala/inox/solvers/theories/MapMergeEncoder.scala
+++ b/src/main/scala/inox/solvers/theories/MapMergeEncoder.scala
@@ -1,0 +1,66 @@
+/* Copyright 2009-2020 EPFL, Lausanne */
+
+package inox
+package solvers
+package theories
+
+trait MapMergeEncoder extends SimpleEncoder {
+  import trees._
+
+  object MapMergeEncoded {
+    def apply(e: MapMerge)(implicit s: Symbols): Expr = {
+      val MapMerge(mask, map1, map2) = e
+      val mapTpe @ MapType(keyTpe, _) = map1.getType
+      val (mapVd, keyVd) = (ValDef.fresh("map", mapTpe), ValDef.fresh("x", keyTpe))
+      val (mapV, keyV) = (mapVd.toVariable, keyVd.toVariable)
+      val cond = Equals(
+        MapApply(mapV, keyV).copiedFrom(e),
+        IfExpr(
+          ElementOfSet(keyV, mask).copiedFrom(e),
+          MapApply(map1, keyV).copiedFrom(e),
+          MapApply(map2, keyV).copiedFrom(e)).copiedFrom(e)).copiedFrom(e)
+      Choose(mapVd, Forall(Seq(keyVd), cond).copiedFrom(e)).copiedFrom(e)
+    }
+
+    def unapply(e: Expr)(implicit s: Symbols): Option[(Expr, Expr, Expr)] =
+      e match {
+        case Choose(mapVd, Forall(Seq(keyVd),
+            Equals(
+              MapApply(mapV1: Variable, keyV1: Variable),
+              IfExpr(
+                ElementOfSet(keyV2: Variable, mask),
+                MapApply(map1, keyV3: Variable),
+                MapApply(map2, keyV4: Variable)))))
+            if keyV1.id == keyVd.id && keyV2.id == keyVd.id &&
+               keyV3.id == keyVd.id && keyV4.id == keyVd.id &&
+               mapV1.id == mapVd.id =>
+          Some((mask, map1, map2))
+        case _ => None
+      }
+  }
+
+  protected object encoder extends SelfTreeTransformer {
+    import sourceProgram._
+
+    override def transform(e: Expr): Expr = e match {
+      case e: MapMerge => transform(MapMergeEncoded(e))
+      case _ => super.transform(e)
+    }
+  }
+
+  protected object decoder extends SelfTreeTransformer {
+    import targetProgram._
+
+    override def transform(e: Expr): Expr = e match {
+      case MapMergeEncoded(mask, map1, map2) =>
+        MapMerge(transform(mask), transform(map1), transform(map2)).copiedFrom(e)
+      case _ => super.transform(e)
+    }
+  }
+}
+
+object MapMergeEncoder {
+  def apply(p: Program): MapMergeEncoder { val sourceProgram: p.type } = new {
+    val sourceProgram: p.type = p
+  } with MapMergeEncoder
+}

--- a/src/main/scala/inox/solvers/theories/MapMergeEncoder.scala
+++ b/src/main/scala/inox/solvers/theories/MapMergeEncoder.scala
@@ -16,7 +16,7 @@ trait MapMergeEncoder extends SimpleEncoder {
         choose("map" :: mapTpe) { map =>
           forall("x" :: keyT) { x =>
             MapApply(map, x) ===
-            (if_ (ElementOfSet(mask, x)) {
+            (if_ (ElementOfSet(x, mask)) {
               MapApply(map1, x)
             } else_ {
               MapApply(map2, x)

--- a/src/main/scala/inox/solvers/theories/package.scala
+++ b/src/main/scala/inox/solvers/theories/package.scala
@@ -24,7 +24,10 @@ package object theories {
     val stringEncoder = ASCIIStringEncoder(enc.targetProgram)
     val encAndString = enc andThen stringEncoder
     val bagEncoder = BagEncoder(encAndString)(ev)
-    stringEncoder andThen bagEncoder
+    val mapMergeEncoder = MapMergeEncoder(bagEncoder.targetProgram)
+
+    val e1 = stringEncoder andThen bagEncoder
+    e1 andThen mapMergeEncoder
   }
 
   def Princess(enc: ProgramTransformer)
@@ -36,15 +39,17 @@ package object theories {
 
     val encAndString = enc andThen stringEncoder
     val bagEncoder = BagEncoder(encAndString)(ev)
+    val mapMergeEncoder = MapMergeEncoder(bagEncoder.targetProgram)
 
-    val setEncoder = SetEncoder(bagEncoder.targetProgram)
+    val setEncoder = SetEncoder(mapMergeEncoder.targetProgram)
 
     val realEncoder = RealEncoder(setEncoder.targetProgram)
 
     // @nv: Required due to limitations in scalac existential types
     val e1 = stringEncoder andThen bagEncoder
-    val e2 = e1 andThen setEncoder
-    e2 andThen realEncoder
+    val e2 = e1 andThen mapMergeEncoder
+    val e3 = e2 andThen setEncoder
+    e3 andThen realEncoder
   }
 
   object ReverseEvaluator {

--- a/src/main/scala/inox/solvers/z3/Z3Native.scala
+++ b/src/main/scala/inox/solvers/z3/Z3Native.scala
@@ -470,6 +470,22 @@ trait Z3Native extends ADTManagers with Interruptible { self: AbstractSolver =>
           case (array, (k, v)) => z3.mkStore(array, rec(k), rec(v))
         }
 
+      case MapMerge(mask, map1, map2) =>
+        def getIteFuncDecl(valueTpe: Type) = {
+          val valueSort = typeToSort(valueTpe)
+          val app = z3.mkITE(
+            z3.mkFreshConst("b", typeToSort(BooleanType())),
+            z3.mkFreshConst("v1", valueSort),
+            z3.mkFreshConst("v2", valueSort))
+          z3.getASTKind(app) match {
+            case Z3AppAST(decl, _) => decl
+            case _ => error("Unexpected non-app AST " + app)
+          }
+        }
+
+        val MapType(_, valueTpe) = map1.getType
+        z3.mkArrayMap(getIteFuncDecl(valueTpe), rec(mask), rec(map1), rec(map2))
+
       /* ====== String operations ====
        * FIXME: replace z3 strings with sequences once they are fixed (in z3)
        */

--- a/src/main/scala/inox/solvers/z3/Z3Native.scala
+++ b/src/main/scala/inox/solvers/z3/Z3Native.scala
@@ -471,6 +471,7 @@ trait Z3Native extends ADTManagers with Interruptible { self: AbstractSolver =>
         }
 
       case MapMerge(mask, map1, map2) =>
+        // TODO: This should move to scala-z3
         def getIteFuncDecl(valueTpe: Type) = {
           val valueSort = typeToSort(valueTpe)
           val app = z3.mkITE(

--- a/src/main/scala/inox/tip/MapExtensions.scala
+++ b/src/main/scala/inox/tip/MapExtensions.scala
@@ -1,0 +1,12 @@
+/* Copyright 2009-2020 EPFL, Lausanne */
+
+package inox
+package tip
+
+import smtlib.theories.Operations._
+
+object MapExtensions {
+  private val MapMerge = "map.merge"
+
+  object Merge extends Operation3 { override val name = MapMerge }
+}

--- a/src/main/scala/inox/tip/Parser.scala
+++ b/src/main/scala/inox/tip/Parser.scala
@@ -547,6 +547,9 @@ class Parser(reader: Reader, file: Option[File]) {
       case Bags.Insert(bag, es @ _*) =>
         es.foldLeft(fromSMT(bag))((b,e) => BagAdd(b, fromSMT(e)))
 
+      case MapExtensions.Merge(mask, map1, map2) =>
+        MapMerge(fromSMT(mask), fromSMT(map1), fromSMT(map2))
+
       case Match(s, cases) =>
         val scrut = fromSMT(s)
         val matchCases: Seq[(Option[Expr], Expr)] = cases.map(cse => cse.pattern match {

--- a/src/main/scala/inox/tip/Printer.scala
+++ b/src/main/scala/inox/tip/Printer.scala
@@ -326,6 +326,9 @@ class Printer(val program: InoxProgram, val context: Context, writer: Writer) ex
     case SetUnion(s1, s2) => Sets.Union(toSMT(s1), toSMT(s2))
     case SetDifference(s1, s2) => Sets.Setminus(toSMT(s1), toSMT(s2))
 
+    case MapMerge(mask, map1, map2) =>
+      MapExtensions.Merge(toSMT(mask), toSMT(map1), toSMT(map2))
+
     case StringLiteral(value) => Strings.StringLit(value)
     case StringConcat(s1, s2) => Strings.Concat(toSMT(s1), toSMT(s2))
     case SubString(s, start, end) => Strings.Substring(toSMT(s), toSMT(start), toSMT(end))

--- a/src/main/scala/inox/utils/Serialization.scala
+++ b/src/main/scala/inox/utils/Serialization.scala
@@ -526,7 +526,7 @@ class InoxSerializer(val trees: ast.Trees, serializeProducts: Boolean = false) e
     * The `Serializer[_]` identifiers in this mapping range from 10 to 102
     * (ignoring special identifiers that are smaller than 10).
     *
-    * NEXT ID: 103
+    * NEXT ID: 104
     */
   protected def classSerializers: Map[Class[_], Serializer[_]] = Map(
     // Inox Expressions
@@ -636,6 +636,7 @@ class InoxSerializer(val trees: ast.Trees, serializeProducts: Boolean = false) e
     classSerializer[ADTSort]       (96),
     classSerializer[ADTConstructor](97),
     classSerializer[FunDef]        (98),
+    classSerializer[MapMerge]      (103),
 
     classOf[SerializationResult] -> ResultSerializer
   )


### PR DESCRIPTION
This PR adds a new tree `MapMerge(mask, map1, map2)` which takes a set `mask : Set[K]` and two maps `map1, map2 : Map[K, V]`. It produces a map combining `map1` and `map2`, picking values from `map1` whenever `k elemOf mask`.

This is encoded efficiently in the extended array theory of Z3. For other solvers we encode `MapMerge(mask, map1, map2)` as `Choose(m:Map[K,V] => forall x:K. m(k) = if (mask(k)) map1(k) else map2(k))`. In practice, CVC4 and Princess seem to simply return `Unknown` in the presence of `MapMerge`.

I added a few (very basic) tests for `nativez3`, `unrollz3` and `smt-z3`.