### PR TITLE
Fix writeId in InoxSerializer

### DIFF
--- a/src/main/scala/inox/utils/Serialization.scala
+++ b/src/main/scala/inox/utils/Serialization.scala
@@ -182,7 +182,7 @@ class InoxSerializer(val trees: ast.Trees, serializeProducts: Boolean = false) e
     // We optimize here for small ids, which corresponds to few registered serializers.
     // We assume this number shouldn't be larger than 255 anyway.
     var currId = id
-    while (currId > 255) {
+    while (currId >= 255) {
       out.write(255.toByte)
       currId -= 255
     }


### PR DESCRIPTION
In `InoxSerializer`, `writeId(255)` produces `0xff`, but during deserialization `readId()` will continue to read past that byte, corrupting the input stream. Instead, `writeId(255)` should produce `0xff 0x00`.