### PR TITLE
Add support for smt-z3 with custom executable name

### DIFF
--- a/src/main/scala/inox/Options.scala
+++ b/src/main/scala/inox/Options.scala
@@ -223,10 +223,7 @@ object optSelectedSolvers extends SetOptionDef[String] {
   val name = "solvers"
   val default = Set("nativez3")
   val elementParser: OptionParser[String] = { s =>
-    stringParser(s).filter(name =>
-      solvers.SolverFactory.solverNames.contains(name) ||
-      name.startsWith("smt-z3:")
-    )
+    stringParser(s).filter(solvers.SolverFactory.supportedSolver)
   }
 
   val usageRhs = "s1,s2,..."

--- a/src/main/scala/inox/Options.scala
+++ b/src/main/scala/inox/Options.scala
@@ -223,7 +223,10 @@ object optSelectedSolvers extends SetOptionDef[String] {
   val name = "solvers"
   val default = Set("nativez3")
   val elementParser: OptionParser[String] = { s =>
-    stringParser(s).filter(solvers.SolverFactory.solverNames contains _)
+    stringParser(s).filter(name =>
+      solvers.SolverFactory.solverNames.contains(name) ||
+      name.startsWith("smt-z3:")
+    )
   }
 
   val usageRhs = "s1,s2,..."

--- a/src/main/scala/inox/solvers/SolverFactory.scala
+++ b/src/main/scala/inox/solvers/SolverFactory.scala
@@ -221,7 +221,7 @@ object SolverFactory {
         }
       })
 
-      case _ if finalName.startsWith("smt-z3") => create(p)(finalName, {
+      case _ if finalName == "smt-z3" || finalName.startsWith("smt-z3:") => create(p)(finalName, {
         val chooseEnc = ChooseEncoder(p)(enc)
         val fullEnc = enc andThen chooseEnc
         val theoryEnc = theories.Z3(fullEnc.targetProgram)

--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -58,7 +58,7 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
   protected val interpreter = {
     val opts = interpreterOpts
     reporter.debug("Invoking solver "+targetName+" with "+opts.mkString(" "))
-    new Z3Interpreter("z3", opts.toArray) {
+    new Z3Interpreter(targetName, opts.toArray) {
       override lazy val parser: Z3Parser = new Z3Parser(new Lexer(out))
     }
   }


### PR DESCRIPTION
This should allow mixing several Z3 versions in portfolio mode: `--solvers=smt-z3,smt-z3:z3-4.8.10,smt-cvc4`