### PR TITLE
Add support for non-incremental mode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test;it",
+  "org.scalatest" %% "scalatest" % "3.2.7" % "test;it",
   "org.apache.commons" % "commons-lang3" % "3.4",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "uuverifiers" %% "princess" % "2018-02-26"

--- a/build.sbt
+++ b/build.sbt
@@ -40,9 +40,12 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.1" % "test;it",
   "org.apache.commons" % "commons-lang3" % "3.4",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  "com.regblanc" %% "scala-smtlib" % "0.2.2-7-g00a9686",
   "uuverifiers" %% "princess" % "2018-02-26"
 )
+
+def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
+// lazy val smtlib = RootProject(file("../scala-smtlib"))
+lazy val smtlib = ghProject("https://github.com/epfl-lara/scala-smtlib.git", "5b9503e13d69c7116039a243025b2ce657c32c77")
 
 lazy val scriptName = settingKey[String]("Name of the generated 'inox' script")
 
@@ -127,6 +130,8 @@ lazy val root = (project in file("."))
     parallelExecution := false
   )) : _*)
   .settings(compile := ((compile in Compile) dependsOn script dependsOn genDoc).value)
+  .dependsOn(smtlib)
+  
 
 publishMavenStyle := true
 

--- a/src/it/scala/inox/ResourceUtils.scala
+++ b/src/it/scala/inox/ResourceUtils.scala
@@ -2,7 +2,7 @@
 
 package inox
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.concurrent._
 
 import java.io.File

--- a/src/it/scala/inox/TestSuite.scala
+++ b/src/it/scala/inox/TestSuite.scala
@@ -2,12 +2,15 @@
 
 package inox
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.concurrent._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.Tag
+import org.scalatest.exceptions
 
 import utils._
 
-trait TestSuite extends FunSuite with Matchers with TimeLimits {
+trait TestSuite extends AnyFunSuite with Matchers with TimeLimits {
 
   protected def configurations: Seq[Seq[OptionValue[_]]] = Seq(Seq.empty)
 

--- a/src/it/scala/inox/tip/TipPrintingSuite.scala
+++ b/src/it/scala/inox/tip/TipPrintingSuite.scala
@@ -3,9 +3,9 @@
 package inox
 package tip
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class TipPrintingSuite extends FunSuite with ResourceUtils {
+class TipPrintingSuite extends AnyFunSuite with ResourceUtils {
   import inox.trees._
 
   val ctx = TestContext.empty

--- a/src/it/scala/inox/tip/TipSerializationSuite.scala
+++ b/src/it/scala/inox/tip/TipSerializationSuite.scala
@@ -3,9 +3,9 @@
 package inox
 package tip
 
-import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
 
-class TipSerializationSuite extends FunSpec with ResourceUtils {
+class TipSerializationSuite extends AnyFunSpec with ResourceUtils {
   import inox.trees._
 
   val ctx = TestContext.empty

--- a/src/it/scala/inox/tip/TipTestSuite.scala
+++ b/src/it/scala/inox/tip/TipTestSuite.scala
@@ -13,12 +13,14 @@ class TipTestSuite extends TestSuite with ResourceUtils {
     Seq(optSelectedSolvers(Set("nativez3")), optCheckModels(true)),
     Seq(optSelectedSolvers(Set("smt-z3")),   optCheckModels(true)),
     Seq(optSelectedSolvers(Set("smt-cvc4")), optCheckModels(true)),
-    Seq(optSelectedSolvers(Set("smt-z3")),   optCheckModels(true), optAssumeChecked(true))
+    Seq(optSelectedSolvers(Set("smt-z3")),   optCheckModels(true), optAssumeChecked(true)),
+    Seq(optSelectedSolvers(Set("smt-z3")),   optCheckModels(true), optNonIncremental(true))
   )
 
   override protected def optionsString(options: Options): String = {
     "solver=" + options.findOptionOrDefault(optSelectedSolvers).head +
-    (if (options.findOptionOrDefault(optAssumeChecked)) " assumechecked" else "")
+    (if (options.findOptionOrDefault(optAssumeChecked)) " assumechecked" else "") +
+    (if (options.findOptionOrDefault(optNonIncremental)) " --no-incremental" else "")
   }
 
   private def ignoreSAT(ctx: Context, file: java.io.File): FilterStatus = 

--- a/src/it/scala/inox/tip/TipTestSuite.scala
+++ b/src/it/scala/inox/tip/TipTestSuite.scala
@@ -10,17 +10,16 @@ import scala.language.existentials
 class TipTestSuite extends TestSuite with ResourceUtils {
 
   override def configurations = Seq(
-    Seq(optSelectedSolvers(Set("nativez3")), optCheckModels(true)),
-    Seq(optSelectedSolvers(Set("smt-z3")),   optCheckModels(true)),
-    Seq(optSelectedSolvers(Set("smt-cvc4")), optCheckModels(true)),
-    Seq(optSelectedSolvers(Set("smt-z3")),   optCheckModels(true), optAssumeChecked(true)),
-    Seq(optSelectedSolvers(Set("smt-z3")),   optCheckModels(true), optNonIncremental(true))
+    Seq(optSelectedSolvers(Set("nativez3")),      optCheckModels(true)),
+    Seq(optSelectedSolvers(Set("smt-z3")),        optCheckModels(true)),
+    Seq(optSelectedSolvers(Set("smt-cvc4")),      optCheckModels(true)),
+    Seq(optSelectedSolvers(Set("smt-z3")),        optCheckModels(true), optAssumeChecked(true)),
+    Seq(optSelectedSolvers(Set("no-inc:smt-z3")), optCheckModels(true))
   )
 
   override protected def optionsString(options: Options): String = {
     "solver=" + options.findOptionOrDefault(optSelectedSolvers).head +
-    (if (options.findOptionOrDefault(optAssumeChecked)) " assumechecked" else "") +
-    (if (options.findOptionOrDefault(optNonIncremental)) " --no-incremental" else "")
+    (if (options.findOptionOrDefault(optAssumeChecked)) " assumechecked" else "")
   }
 
   private def ignoreSAT(ctx: Context, file: java.io.File): FilterStatus = 

--- a/src/main/scala/inox/Main.scala
+++ b/src/main/scala/inox/Main.scala
@@ -52,7 +52,7 @@ trait MainHelpers {
       solvers.SolverFactory.solverNames.toSeq.sortBy(_._1).map {
         case (name, desc) => f"\n  $name%-14s : $desc"
       }.mkString("") +
-      "\nYou can prefix the solvers unrollz3, smt-z3, smt-z3:<exec>, smt-cvc4, with 'noinc:' to use them in non-incremental mode"
+      "\nYou can prefix the solvers unrollz3, smt-z3, smt-z3:<exec> and smt-cvc4, with 'no-inc:' to use them in non-incremental mode"
     }),
     optDebug -> Description(General, {
       val sects = debugSections.toSeq.map(_.name).sorted

--- a/src/main/scala/inox/Main.scala
+++ b/src/main/scala/inox/Main.scala
@@ -46,13 +46,13 @@ trait MainHelpers {
   protected def getOptions: Map[OptionDef[_], Description] = Map(
     optHelp -> Description(General, "Show help message"),
     optNoColors -> Description(General, "Disable colored output and non-ascii characters (enable this option for better support in IDEs)"),
-    optNonIncremental -> Description(General, "Disable incremental mode in solvers"),
     optTimeout -> Description(General, "Set a timeout for the solver (in sec.)"),
     optSelectedSolvers -> Description(General, {
       "Use solvers s1,s2,...\nAvailable: " +
       solvers.SolverFactory.solverNames.toSeq.sortBy(_._1).map {
         case (name, desc) => f"\n  $name%-14s : $desc"
-      }.mkString("")
+      }.mkString("") +
+      "\nYou can prefix the solvers unrollz3, smt-z3, smt-z3:<exec>, smt-cvc4, with 'noinc:' to use them in non-incremental mode"
     }),
     optDebug -> Description(General, {
       val sects = debugSections.toSeq.map(_.name).sorted

--- a/src/main/scala/inox/Main.scala
+++ b/src/main/scala/inox/Main.scala
@@ -11,6 +11,7 @@ trait MainHelpers {
   protected def getDebugSections: Set[DebugSection] = Set(
     utils.DebugSectionTimers,
     solvers.DebugSectionSolver,
+    solvers.smtlib.DebugSectionSMT,
     tip.DebugSectionTip
   )
 
@@ -45,6 +46,7 @@ trait MainHelpers {
   protected def getOptions: Map[OptionDef[_], Description] = Map(
     optHelp -> Description(General, "Show help message"),
     optNoColors -> Description(General, "Disable colored output and non-ascii characters (enable this option for better support in IDEs)"),
+    optNonIncremental -> Description(General, "Disable incremental mode in solvers"),
     optTimeout -> Description(General, "Set a timeout for the solver (in sec.)"),
     optSelectedSolvers -> Description(General, {
       "Use solvers s1,s2,...\nAvailable: " +

--- a/src/main/scala/inox/Options.scala
+++ b/src/main/scala/inox/Options.scala
@@ -232,3 +232,5 @@ object optSelectedSolvers extends SetOptionDef[String] {
 }
 
 object optNoColors extends inox.FlagOptionDef("no-colors", false)
+
+object optNonIncremental extends inox.FlagOptionDef("no-incremental", false)

--- a/src/main/scala/inox/Options.scala
+++ b/src/main/scala/inox/Options.scala
@@ -232,5 +232,3 @@ object optSelectedSolvers extends SetOptionDef[String] {
 }
 
 object optNoColors extends inox.FlagOptionDef("no-colors", false)
-
-object optNonIncremental extends inox.FlagOptionDef("no-incremental", false)

--- a/src/main/scala/inox/solvers/combinators/NonIncrementalSolver.scala
+++ b/src/main/scala/inox/solvers/combinators/NonIncrementalSolver.scala
@@ -28,6 +28,8 @@ trait NonIncrementalSolver extends AbstractSolver { self =>
   def interrupt(): Unit = for (solver <- currentSolver) solver.interrupt()
 
   override def check(config: CheckConfiguration): config.Response[Model, Assumptions] = {
+    assert(currentSolver.isEmpty,
+      "`currentSolver` should be empty when invoking `check` in NonIncrementalSolver")
     val newSolver = underlying()
     try {
       currentSolver = Some(newSolver)
@@ -43,6 +45,8 @@ trait NonIncrementalSolver extends AbstractSolver { self =>
 
   override def checkAssumptions(config: Configuration)
                                (assumptions: Set[Trees]): config.Response[Model, Assumptions] = {
+    assert(currentSolver.isEmpty,
+      "`currentSolver` should be empty when invoking `checkAssumptions` in NonIncrementalSolver")
     val newSolver = underlying()
     try {
       currentSolver = Some(newSolver)

--- a/src/main/scala/inox/solvers/combinators/NonIncrementalSolver.scala
+++ b/src/main/scala/inox/solvers/combinators/NonIncrementalSolver.scala
@@ -29,25 +29,31 @@ trait NonIncrementalSolver extends AbstractSolver { self =>
 
   override def check(config: CheckConfiguration): config.Response[Model, Assumptions] = {
     val newSolver = underlying()
-    currentSolver = Some(newSolver)
-    for (expression <- assertions)
-      newSolver.assertCnstr(expression)
-    val res = newSolver.check(config)
-    newSolver.free()
-    currentSolver = None
-    res
+    try {
+      currentSolver = Some(newSolver)
+      for (expression <- assertions)
+        newSolver.assertCnstr(expression)
+      val res = newSolver.check(config)
+      currentSolver = None
+      res
+    } finally {
+      newSolver.free()
+    }
   }
 
   override def checkAssumptions(config: Configuration)
                                (assumptions: Set[Trees]): config.Response[Model, Assumptions] = {
     val newSolver = underlying()
-    currentSolver = Some(newSolver)
-    for (expression <- assertions)
-      newSolver.assertCnstr(expression)
-    val res = newSolver.checkAssumptions(config)(assumptions)
-    newSolver.free()
-    currentSolver = None
-    res
+    try {
+      currentSolver = Some(newSolver)
+      for (expression <- assertions)
+        newSolver.assertCnstr(expression)
+      val res = newSolver.checkAssumptions(config)(assumptions)
+      currentSolver = None
+      res
+    } finally {
+      newSolver.free()
+    }
   }
 
   def push(): Unit = assertions.push()

--- a/src/main/scala/inox/solvers/combinators/NonIncrementalSolver.scala
+++ b/src/main/scala/inox/solvers/combinators/NonIncrementalSolver.scala
@@ -1,0 +1,49 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package inox
+package solvers
+package combinators
+
+import utils._
+import scala.concurrent.duration._
+import scala.collection.mutable.ArrayBuffer
+
+trait NonIncrementalSolver extends AbstractSolver { self =>
+  import program.trees._
+  import SolverResponses._
+
+  protected def underlying(): AbstractSolver {
+    val program: self.program.type
+    type Trees = self.Trees
+    type Model = self.Model
+  }
+
+  val assertions: IncrementalSet[Trees] = new IncrementalSet[Trees]
+
+  val allSolvers: ArrayBuffer[AbstractSolver] = ArrayBuffer()
+
+  def assertCnstr(expression: Trees): Unit = assertions += expression
+  def reset(): Unit = assertions.clear()
+  def free(): Unit = for (solver <- allSolvers) solver.free()
+  def interrupt(): Unit = for (solver <- allSolvers) solver.interrupt()
+
+  override def check(config: CheckConfiguration): config.Response[Model, Assumptions] = {
+    val newSolver = underlying()
+    allSolvers.append(newSolver)
+    for (expression <- assertions)
+      newSolver.assertCnstr(expression)
+    newSolver.check(config)
+  }
+
+  override def checkAssumptions(config: Configuration)
+                               (assumptions: Set[Trees]): config.Response[Model, Assumptions] = {
+    val newSolver = underlying()
+    allSolvers.append(newSolver)
+    for (expression <- assertions)
+      newSolver.assertCnstr(expression)
+    newSolver.checkAssumptions(config)(assumptions)
+  }
+
+  def push(): Unit = assertions.push()
+  def pop(): Unit = assertions.pop()
+}

--- a/src/main/scala/inox/solvers/smtlib/SMTLIBDebugger.scala
+++ b/src/main/scala/inox/solvers/smtlib/SMTLIBDebugger.scala
@@ -7,6 +7,8 @@ package smtlib
 import utils._
 import _root_.smtlib.trees.Terms._
 
+case object DebugSectionSMT extends DebugSection("smt")
+
 trait SMTLIBDebugger extends SMTLIBTarget {
   import context._
   import program._
@@ -22,6 +24,7 @@ trait SMTLIBDebugger extends SMTLIBTarget {
 
   /* Printing VCs */
   protected lazy val debugOut: Option[java.io.FileWriter] = {
+    implicit val debugSection = DebugSectionSMT
     if (reporter.isDebugEnabled) {
       val file = options.findOptionOrDefault(Main.optFiles).headOption.map(_.getName).getOrElse("NA")
       val n = DebugFileNumbers.next(targetName + file)

--- a/src/main/scala/inox/solvers/smtlib/SMTLIBSolver.scala
+++ b/src/main/scala/inox/solvers/smtlib/SMTLIBSolver.scala
@@ -114,8 +114,8 @@ trait SMTLIBSolver extends AbstractSolver with SMTLIBTarget with SMTLIBDebugger 
       if (config.withUnsatAssumptions) {
         emit(GetUnsatAssumptions()) match {
           case GetUnsatAssumptionsResponseSuccess(syms) =>
-            UnsatWithAssumptions(syms.flatMap { s =>
-              variables.getA(s).flatMap { v =>
+            UnsatWithAssumptions(syms.flatMap { lit =>
+              variables.getA(lit.symbol).flatMap { v =>
                 if (assumptions(v)) Some(v)
                 else if (assumptions(Not(v))) Some(Not(v))
                 else None

--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -48,7 +48,7 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
               Error(msg)
             case t =>
               val props = parseUntil(Tokens.CParen)(parsePropLit _)
-              GetUnsatAssumptionsResponseSuccess(props.map(_.symbol))
+              GetUnsatAssumptionsResponseSuccess(props)
           }
         }
       }

--- a/src/test/scala/inox/ast/ExprOpsSuite.scala
+++ b/src/test/scala/inox/ast/ExprOpsSuite.scala
@@ -3,9 +3,9 @@
 package inox
 package ast
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class ExprOpsSuite extends FunSuite {
+class ExprOpsSuite extends AnyFunSuite {
   import inox.trees._
   import inox.trees.exprOps._
 

--- a/src/test/scala/inox/ast/ExtractorsSuite.scala
+++ b/src/test/scala/inox/ast/ExtractorsSuite.scala
@@ -3,9 +3,9 @@
 package inox
 package ast
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class ExtractorsSuite extends FunSuite {
+class ExtractorsSuite extends AnyFunSuite {
   import inox.trees._
 
   test("Extractors do not simplify basic arithmetic") {

--- a/src/test/scala/inox/ast/TreeTestsSuite.scala
+++ b/src/test/scala/inox/ast/TreeTestsSuite.scala
@@ -3,11 +3,11 @@
 package inox
 package ast
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
 import inox.trees._
 
-class TreeTestsSuite extends FunSuite {
+class TreeTestsSuite extends AnyFunSuite {
 
   test("And- and Or- simplifications") {
     val x = Variable.fresh("x", BooleanType())

--- a/src/test/scala/inox/evaluators/EvaluatorSuite.scala
+++ b/src/test/scala/inox/evaluators/EvaluatorSuite.scala
@@ -3,9 +3,9 @@
 package inox
 package evaluators
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class EvaluatorSuite extends FunSuite {
+class EvaluatorSuite extends AnyFunSuite {
   import inox.trees._
 
   val ctx = TestContext.empty

--- a/src/test/scala/inox/parsing/ArithmeticParserSuite.scala
+++ b/src/test/scala/inox/parsing/ArithmeticParserSuite.scala
@@ -1,9 +1,9 @@
 package inox
 package parsing
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class ArithmeticParserSuite extends FunSuite {
+class ArithmeticParserSuite extends AnyFunSuite {
 
   import inox.trees._
   import interpolator._

--- a/src/test/scala/inox/parsing/BooleanOperationsParserSuite.scala
+++ b/src/test/scala/inox/parsing/BooleanOperationsParserSuite.scala
@@ -1,9 +1,9 @@
 package inox
 package parsing
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class BooleanOperationsParserSuite extends FunSuite {
+class BooleanOperationsParserSuite extends AnyFunSuite {
 
   import inox.trees._
   import interpolator._

--- a/src/test/scala/inox/parsing/ComparisonOperationsParserSuite.scala
+++ b/src/test/scala/inox/parsing/ComparisonOperationsParserSuite.scala
@@ -1,9 +1,9 @@
 package inox
 package parsing
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class ComparisonOperationsParserSuite extends FunSuite {
+class ComparisonOperationsParserSuite extends AnyFunSuite {
 
   import inox.trees._
   import interpolator._

--- a/src/test/scala/inox/parsing/ExprLiteralParserSuite.scala
+++ b/src/test/scala/inox/parsing/ExprLiteralParserSuite.scala
@@ -2,9 +2,9 @@ package inox
 package parsing
 
 import scala.collection.BitSet
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class ExprLiteralParserSuite extends FunSuite {
+class ExprLiteralParserSuite extends AnyFunSuite {
 
   import inox.trees._
   import interpolator._

--- a/src/test/scala/inox/parsing/ExtractorSuite.scala
+++ b/src/test/scala/inox/parsing/ExtractorSuite.scala
@@ -1,9 +1,9 @@
 package inox
 package parsing
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class ExtractorSuite extends FunSuite {
+class ExtractorSuite extends AnyFunSuite {
 
   import inox.trees._
   import interpolator._

--- a/src/test/scala/inox/parsing/OperationsPrecedenceParserSuite.scala
+++ b/src/test/scala/inox/parsing/OperationsPrecedenceParserSuite.scala
@@ -1,9 +1,9 @@
 package inox
 package parsing
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class OperationsPrecedenceParserSuite extends FunSuite {
+class OperationsPrecedenceParserSuite extends AnyFunSuite {
 
   import inox.trees._
   import interpolator._

--- a/src/test/scala/inox/parsing/QuantifierParserSuite.scala
+++ b/src/test/scala/inox/parsing/QuantifierParserSuite.scala
@@ -1,9 +1,9 @@
 package inox
 package parsing
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class QuantifierParserSuite extends FunSuite {
+class QuantifierParserSuite extends AnyFunSuite {
 
   import inox.trees._
   import interpolator._

--- a/src/test/scala/inox/parsing/TypeParserSuite.scala
+++ b/src/test/scala/inox/parsing/TypeParserSuite.scala
@@ -1,9 +1,9 @@
 package inox
 package parsing
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class TypeParserSuite extends FunSuite {
+class TypeParserSuite extends AnyFunSuite {
 
   import inox.trees._
   import interpolator._

--- a/src/test/scala/inox/solvers/SemanticsSuite.scala
+++ b/src/test/scala/inox/solvers/SemanticsSuite.scala
@@ -3,9 +3,10 @@
 package inox
 package solvers
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.Tag
 
-class SemanticsSuite extends FunSuite {
+class SemanticsSuite extends AnyFunSuite {
   import inox.trees._
   import inox.trees.dsl._
   import SolverResponses._

--- a/src/test/scala/inox/solvers/SolverPoolSuite.scala
+++ b/src/test/scala/inox/solvers/SolverPoolSuite.scala
@@ -3,11 +3,11 @@
 package inox
 package solvers
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
 import inox.solvers.combinators._
 
-class SolverPoolSuite extends FunSuite {
+class SolverPoolSuite extends AnyFunSuite {
   import inox.trees._
   import SolverResponses._
 

--- a/src/test/scala/inox/solvers/SolversSuite.scala
+++ b/src/test/scala/inox/solvers/SolversSuite.scala
@@ -3,9 +3,9 @@
 package inox
 package solvers
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class SolversSuite extends FunSuite {
+class SolversSuite extends AnyFunSuite {
   import inox.trees._
   import SolverResponses._
 

--- a/src/test/scala/inox/solvers/TimeoutSolverSuite.scala
+++ b/src/test/scala/inox/solvers/TimeoutSolverSuite.scala
@@ -3,9 +3,9 @@
 package inox
 package solvers
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class TimeoutSolverSuite extends FunSuite {
+class TimeoutSolverSuite extends AnyFunSuite {
   import inox.trees._
   import dsl._
 

--- a/src/test/scala/inox/utils/BijectionSuite.scala
+++ b/src/test/scala/inox/utils/BijectionSuite.scala
@@ -2,9 +2,9 @@
 
 package inox.utils
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class BijectionSuite extends FunSuite {
+class BijectionSuite extends AnyFunSuite {
 
   test("Empty Bijection returns None") {
     val b = new Bijection[Int, Int]

--- a/src/test/scala/inox/utils/GraphsSuite.scala
+++ b/src/test/scala/inox/utils/GraphsSuite.scala
@@ -2,11 +2,11 @@
 
 package inox.utils
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
 import Graphs._
 
-class GraphsSuite extends FunSuite {
+class GraphsSuite extends AnyFunSuite {
   abstract class Node
   case object A extends Node
   case object B extends Node

--- a/src/test/scala/inox/utils/IncrementalBijectionSuite.scala
+++ b/src/test/scala/inox/utils/IncrementalBijectionSuite.scala
@@ -2,9 +2,9 @@
 
 package inox.utils
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class IncrementalBijectionSuite extends FunSuite {
+class IncrementalBijectionSuite extends AnyFunSuite {
 
   test("Empty IncrementalBijection returns None") {
     val b = new IncrementalBijection[Int, Int]

--- a/src/test/scala/inox/utils/StreamsSuite.scala
+++ b/src/test/scala/inox/utils/StreamsSuite.scala
@@ -2,11 +2,11 @@
 
 package inox.utils
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
 import StreamUtils._
 
-class StreamsSuite extends FunSuite {
+class StreamsSuite extends AnyFunSuite {
 
   test("Cartesian Product 1") {
     val s1 = 1 #::

--- a/src/test/scala/inox/utils/UtilsSuite.scala
+++ b/src/test/scala/inox/utils/UtilsSuite.scala
@@ -2,9 +2,9 @@
 
 package inox.utils
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 
-class UtilsSuite extends FunSuite {
+class UtilsSuite extends AnyFunSuite {
 
   test("fixpoint computes correct fixpoint of function that increments up to a max") {
     def f(x: Int): Int = if(x < 10) x + 1 else 10


### PR DESCRIPTION
Thanks @samarion for the help

Built on top of https://github.com/epfl-lara/inox/pull/137

I wonder now if it wouldn't have been better to make new solver names such as `noinc:smt-z3` instead of one global option.
That way we could mix incremental and non-incremental solvers in one run.
But this will do for now, I'll that for a future PR.