### PR TITLE
Add let case in ChooseEncoder

### DIFF
--- a/src/it/scala/inox/tip/TipTestSuite.scala
+++ b/src/it/scala/inox/tip/TipTestSuite.scala
@@ -39,7 +39,7 @@ class TipTestSuite extends TestSuite with ResourceUtils {
     ctx.options.findOptionOrDefault(optSelectedSolvers).headOption match {
       case Some(solver) => (solver, file.getName) match {
         // Z3 binary will predictably segfault on certain permutations of this problem
-        case ("smt-z3", "MergeSort2.scala-1.tip") => Ignore
+        case ("no-inc:smt-z3" | "smt-z3", "MergeSort2.scala-1.tip") => Ignore
         // use non-linear operators that aren't supported in CVC4
         case ("smt-cvc4", "Instantiation.scala-0.tip") => Skip
         case ("smt-cvc4", "LetsInForall.tip") => Skip

--- a/src/main/scala/inox/solvers/unrolling/ChooseEncoder.scala
+++ b/src/main/scala/inox/solvers/unrolling/ChooseEncoder.scala
@@ -25,13 +25,9 @@ trait ChooseEncoder extends transformers.ProgramTransformer {
 
     val newFds = sourceProgram.symbols.functions.values.toList.map { fd =>
       def rec(e: Expr, params: Seq[ValDef]): Expr = e match {
-        case l: Let =>
-          val free = exprOps.variablesOf(l)
-          l.copy(body = rec(l.body, params.filter(vd => free(vd.toVariable)) :+ l.vd)).copiedFrom(l)
+        case l: Let => l.copy(body = rec(l.body, params :+ l.vd)).copiedFrom(l)
 
-        case l: Lambda =>
-          val free = exprOps.variablesOf(l)
-          l.copy(body = rec(l.body, params.filter(vd => free(vd.toVariable)) ++ l.params)).copiedFrom(l)
+        case l: Lambda => l.copy(body = rec(l.body, params ++ l.params)).copiedFrom(l)
 
         case c: Choose =>
           val (substMap, freshParams) = params.foldLeft((Map[ValDef, Expr](), Seq[ValDef]())) {

--- a/src/main/scala/inox/solvers/unrolling/ChooseEncoder.scala
+++ b/src/main/scala/inox/solvers/unrolling/ChooseEncoder.scala
@@ -25,6 +25,10 @@ trait ChooseEncoder extends transformers.ProgramTransformer {
 
     val newFds = sourceProgram.symbols.functions.values.toList.map { fd =>
       def rec(e: Expr, params: Seq[ValDef]): Expr = e match {
+        case l: Let =>
+          val free = exprOps.variablesOf(l)
+          l.copy(body = rec(l.body, params.filter(vd => free(vd.toVariable)) :+ l.vd)).copiedFrom(l)
+
         case l: Lambda =>
           val free = exprOps.variablesOf(l)
           l.copy(body = rec(l.body, params.filter(vd => free(vd.toVariable)) ++ l.params)).copiedFrom(l)

--- a/src/main/scala/inox/solvers/unrolling/ChooseEncoder.scala
+++ b/src/main/scala/inox/solvers/unrolling/ChooseEncoder.scala
@@ -41,7 +41,7 @@ trait ChooseEncoder extends transformers.ProgramTransformer {
               (substMap + (vd -> nvd.toVariable), vds :+ nvd)
           }
 
-          val newPred = exprOps.replaceFromSymbols(substMap, rec(c.pred, params))
+          val newPred = exprOps.replaceFromSymbols(substMap, rec(c.pred, params :+ c.res))
           val returnType = typeOps.replaceFromSymbols(substMap, c.res.tpe)
 
           val newFd = new FunDef(

--- a/src/main/scala/inox/solvers/unrolling/UnrollingSolver.scala
+++ b/src/main/scala/inox/solvers/unrolling/UnrollingSolver.scala
@@ -164,8 +164,15 @@ trait AbstractUnrollingSolver extends Solver { self =>
 
   def assertCnstr(expression: Expr): Unit = context.timers.solvers.assert.run(try {
     context.timers.solvers.assert.sanity.run {
-      symbols.ensureWellFormed // make sure that the current program is well-formed
-      typeCheck(expression, BooleanType()) // make sure we've asserted a boolean-typed expression
+      try {
+        symbols.ensureWellFormed // make sure that the current program is well-formed
+        typeCheck(expression, BooleanType()) // make sure we've asserted a boolean-typed expression
+      } catch {
+        case _: Throwable =>
+          context.reporter.internalError(
+            "Error while ensuring well-formedness of symbols and expression in `assertCnstr` in `UnrollingSolver`"
+          )
+      }
     }
 
     // Multiple calls to registerForInterrupts are (almost) idempotent and acceptable

--- a/src/main/scala/inox/solvers/unrolling/UnrollingSolver.scala
+++ b/src/main/scala/inox/solvers/unrolling/UnrollingSolver.scala
@@ -164,15 +164,8 @@ trait AbstractUnrollingSolver extends Solver { self =>
 
   def assertCnstr(expression: Expr): Unit = context.timers.solvers.assert.run(try {
     context.timers.solvers.assert.sanity.run {
-      try {
-        symbols.ensureWellFormed // make sure that the current program is well-formed
-        typeCheck(expression, BooleanType()) // make sure we've asserted a boolean-typed expression
-      } catch {
-        case _: Throwable =>
-          context.reporter.internalError(
-            "Error while ensuring well-formedness of symbols and expression in `assertCnstr` in `UnrollingSolver`"
-          )
-      }
+      symbols.ensureWellFormed // make sure that the current program is well-formed
+      typeCheck(expression, BooleanType()) // make sure we've asserted a boolean-typed expression
     }
 
     // Multiple calls to registerForInterrupts are (almost) idempotent and acceptable


### PR DESCRIPTION
Fix an issue that appeared on this Stainless program, where `ChooseEncoder` generates a `choose` function with an unbound variable.

```scala
iimport stainless.lang._
import stainless.lang.StaticChecks.WhileDecorations

object Bug {
  def insert[T](array: Array[T]): Unit = {
    val n: Int = array.length
    var i = n - 1

    (while (true) {
      i += 1

    }).inline.opaque.invariant (
      i <= n-1
    )
  }
}
```