### PR TITLE
Add infoContinue method in Reporter to emit without line return

### DIFF
--- a/src/test/scala/inox/TestSilentReporter.scala
+++ b/src/test/scala/inox/TestSilentReporter.scala
@@ -5,7 +5,9 @@ package inox
 class TestSilentReporter extends DefaultReporter(Set()) {
   var lastErrors: List[String] = Nil
 
-  override def emit(msg: Message): Unit = msg match { 
+  override def infoContinue(msg: Any): Unit = { }
+
+  override def emit(msg: Message): Unit = msg match {
     case Message(ERROR, _, msg) => lastErrors ++= List(msg.toString)
     case Message(FATAL, _, msg) => lastErrors ++= List(msg.toString)
     case _ =>


### PR DESCRIPTION
This is to get the following output in Stainless, where each `.` corresponds to a valid VC.

```scala
[  Info  ] Starting verification..........................
[Warning ] SortedArray.scala:507:14:  => TIMEOUT
                 assert(isSortedRange(array, order, i+2, array.length-1))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^C[  Info  ] 
[Warning ] Interrupted...
[Warning ] SortedArray.scala:508:14:  => CANCELLED
                 assert(order.leq(array(i+1), array(i+2)))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[  Info  ] ......................................................
[Warning ] SortedArray.scala:508:42:  => TIMEOUT
                 assert(order.leq(array(i+1), array(i+2)))
                                                    ^^^
[  Info  ] ..........................................................................................................................................................................................................................
```