### PR TITLE
Fix crash when mapping BitSet to negative values

### DIFF
--- a/src/main/scala/inox/evaluators/RecursiveEvaluator.scala
+++ b/src/main/scala/inox/evaluators/RecursiveEvaluator.scala
@@ -21,7 +21,7 @@ trait RecursiveEvaluator
   lazy val ignoreContracts = options.findOptionOrDefault(optIgnoreContracts)
 
   private def shift(b: BitSet, size: Int, i: Int): BitSet =
-    b.map(_ + i).filter(bit => bit >= 1 && bit <= size)
+    b.filter(bit => bit + i >= 1 && bit + i <= size).map(_ + i)
 
   protected def finiteSet(els: Iterable[Expr], tpe: Type): FiniteSet = {
     FiniteSet(els.toSeq.distinct.sortBy(_.toString), tpe)


### PR DESCRIPTION
This crashes in Scala 2.12.13:

`scala.collection.BitSet(1).map(_ - 1)`
