### PR TITLE
Add debug option to dump blocker graph

### DIFF
--- a/src/main/scala/inox/Main.scala
+++ b/src/main/scala/inox/Main.scala
@@ -12,6 +12,7 @@ trait MainHelpers {
     utils.DebugSectionTimers,
     solvers.DebugSectionSolver,
     solvers.smtlib.DebugSectionSMT,
+    solvers.unrolling.DebugSectionBlockerGraph,
     tip.DebugSectionTip
   )
 

--- a/src/main/scala/inox/solvers/unrolling/TemplateGenerator.scala
+++ b/src/main/scala/inox/solvers/unrolling/TemplateGenerator.scala
@@ -141,7 +141,7 @@ trait TemplateGenerator { self: Templates =>
         newArg
       }
 
-      val newCall = thenCall.tfd.applied(newArgs)
+      val newCall = thenCall.tfd.applied(newArgs).copiedFrom(thenCall)
       builder.storeGuarded(newBlocker, Equals(newExpr, newCall))
     }
 
@@ -514,7 +514,7 @@ trait TemplateGenerator { self: Templates =>
         storeEquality(pathVar, re1, re2)
         Application(v, Seq(re1, re2))
 
-      case Operator(as, r) => r(as.map(a => rec(pathVar, a, None)))
+      case Operator(as, recons) => recons(as.map(a => rec(pathVar, a, None))).copiedFrom(expr)
     }
 
     val p = rec(pathVar, expr, polarity)
@@ -578,7 +578,7 @@ trait TemplateGenerator { self: Templates =>
         and(
           sort.invariant
             .filter(_ => generator == FreeGenerator)
-            .map(_.applied(Seq(expr)))
+            .map(tfd => tfd.applied(Seq(expr)).copiedFrom(tfd))
             .getOrElse(BooleanLiteral(true)),
           if (sort.definition.isInductive && !state.recurseAdt) {
             storeType(pathVar, tpe, expr)


### PR DESCRIPTION
Adds a debug section `blocker-graph` that dumps the (non-strict) implication graph among all blocking literals. The current graph is dumped at the end of `checkAssumptions` and saved in `blocker-graphs/*file*-*n*.dot`.

Nodes that correspond to `defBlocker`s also contain the corresponding function name and the call site's position. The latter is information is unreliable, since we only store the call site position when the callee's `FunctionTemplate` is first cached (the cache key being the `TypedFunDef`).

@samarion Any preference on where to move the dot-graph-dumping code that new lives in `checkAssumptions`?