### PR TITLE
Migrate to Scala 3

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -17,14 +17,14 @@ However, Inox provides all the tools necessary to enable inductive reasoning, as
 Let us start by setting up some useful imports:
 
 ```scala
-import inox._
+import inox.{given, _}
 import inox.trees._
 import inox.trees.dsl._
 import inox.solvers._
 ```
 
 The explanation is the following:
-- `inox._` imports [`InoxProgram` and many others](/src/main/scala/inox/package.scala#L19)
+- `inox.{given, _}` imports [`InoxProgram` and many others](/src/main/scala/inox/package.scala#L19)
 - `inox.trees._` imports the content of the default implementation [`trees`](/src/main/scala/inox/package.scala#L53) extending [`Trees`](/src/main/scala/inox/ast/Trees.scala#L10).
 - `inox.trees.dsl._` imports the [domain-specific-language helpers](/src/main/scala/inox/ast/DSL.scala#L20) to create [`trees`](/src/main/scala/inox/package.scala#L53) expressions.
 - `inox.solvers._` imports the [solvers](/src/main/scala/inox/solvers/package.scala#L8).
@@ -198,9 +198,9 @@ __Note__: Inox will assume the inductive invariant on the recursive call to `siz
 In order to verify the property, we get an instance of an Inox solver (see
 [Programs](/doc/API.md#programs) and [Solvers](/doc/API.md#solvers) for more details):
 ```scala
-implicit val ctx: Context = Context.empty
+given ctx: Context = Context.empty
 val program = inox.Program(inox.trees)(symbols)
-val solver = program.getSolver.getNewSolver
+val solver = program.getSolver.getNewSolver()
 solver.assertCnstr(Not(prop))
 solver.check(SolverResponses.Simple) // Should return `Unsat`
 solver.free()

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.18")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 

--- a/src/it/scala/inox/binary/DeserializationSuite.scala
+++ b/src/it/scala/inox/binary/DeserializationSuite.scala
@@ -21,9 +21,9 @@ class DeserializationSuite extends AnyFunSpec with ResourceUtils {
       val name = file.getName
       val fis = new FileInputStream(file)
       val serializer = utils.Serializer(inox.trees)
-      import serializer._
+      import serializer.{given, _}
 
-      def test[T: ClassTag](expected: T)(implicit p: SerializableOrProcedure[T]): Unit = {
+      def test[T: ClassTag](expected: T)(using SerializableOrProcedure[T]): Unit = {
         val data = serializer.deserialize[T](fis)
         assert(data == expected)
       }

--- a/src/it/scala/inox/solvers/unrolling/BagSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/BagSuite.scala
@@ -45,13 +45,13 @@ class BagSuite extends SolvingTestSuite with DatastructureUtils {
             "tuple" :: T(List(aT), List(aT)),
             E(splitID)(aT)(l.getField(tail).getField(tail))
           ) { tuple => E(
-            Cons(aT)(l.getField(head), tuple._1),
-            Cons(aT)(l.getField(tail).getField(head), tuple._2)
+            Cons(aT)(l.getField(head), tuple._ts1),
+            Cons(aT)(l.getField(tail).getField(head), tuple._ts2)
           )}
         } else_ {
           E(l, Nil(aT)())
         }
-      ) { res => Assume(bag(aT)(l) === BagUnion(bag(aT)(res._1), bag(aT)(res._2)), res) }
+      ) { res => Assume(bag(aT)(l) === BagUnion(bag(aT)(res._ts1), bag(aT)(res._ts2)), res) }
     })
   }
 
@@ -65,20 +65,20 @@ class BagSuite extends SolvingTestSuite with DatastructureUtils {
             "tuple" :: T(List(aT), List(aT)),
             E(splitID)(aT)(l.getField(tail).getField(tail))
           ) { tuple => E(
-            Cons(aT)(l.getField(head), tuple._1),
-            Cons(aT)(l.getField(tail).getField(head), tuple._2)
+            Cons(aT)(l.getField(head), tuple._ts1),
+            Cons(aT)(l.getField(tail).getField(head), tuple._ts2)
           )}
         } else_ {
           E(Nil(aT)(), Nil(aT)())
         }
-      ) { res => Assume(bag(aT)(l) === BagUnion(bag(aT)(res._1), bag(aT)(res._2)), res) }
+      ) { res => Assume(bag(aT)(l) === BagUnion(bag(aT)(res._ts1), bag(aT)(res._ts2)), res) }
     })
   }
 
   val symbols = baseSymbols.withFunctions(Seq(bag, split, split2))
   val program = InoxProgram(symbols)
 
-  test("Finite model finding 1") { implicit ctx =>
+  test("Finite model finding 1") {
     val aT = TypeParameter.fresh("A")
     val b = ("bag" :: BagType(aT)).toVariable
     val clause = Not(Equals(b, FiniteBag(Seq.empty, aT)))
@@ -86,7 +86,7 @@ class BagSuite extends SolvingTestSuite with DatastructureUtils {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Finite model finding 2") { implicit ctx =>
+  test("Finite model finding 2") {
     val aT = TypeParameter.fresh("A")
     val b = ("bag" :: BagType(aT)).toVariable
     val elem = ("elem" :: aT).toVariable
@@ -95,7 +95,7 @@ class BagSuite extends SolvingTestSuite with DatastructureUtils {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Finite model finding 3") { implicit ctx =>
+  test("Finite model finding 3") {
     val aT = TypeParameter.fresh("A")
     val b = ("bag" :: BagType(aT)).toVariable
     val Seq(e1, v1, e2, v2) = Seq("e1" :: aT, "v1" :: IntegerType(), "e2" :: aT, "v2" :: IntegerType()).map(_.toVariable)
@@ -108,7 +108,7 @@ class BagSuite extends SolvingTestSuite with DatastructureUtils {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("split preserves content") { implicit ctx =>
+  test("split preserves content") {
     val Let(vd, body, Assume(pred, _)) = split.fullBody
     val clause = Let(vd, body, pred)
 
@@ -122,7 +122,7 @@ class BagSuite extends SolvingTestSuite with DatastructureUtils {
     else Test
   }
 
-  test("split2 doesn't preserve content", filter(_)) { implicit ctx =>
+  test("split2 doesn't preserve content", filter(_)) {
     val Let(vd, body, Assume(pred, _)) = split2.fullBody
     val clause = Let(vd, body, pred)
 

--- a/src/it/scala/inox/solvers/unrolling/ChooseSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/ChooseSuite.scala
@@ -69,34 +69,34 @@ class ChooseSuite extends SolvingTestSuite {
   val symbols = NoSymbols.withFunctions(Seq(fun1, fun2, fun3, fun4, fun5))
   val program = InoxProgram(symbols)
 
-  test("simple choose") { implicit ctx =>
+  test("simple choose") {
     val clause = choose("v" :: IntegerType())(v => v > IntegerLiteral(0)) === IntegerLiteral(10)
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("choose in function") { implicit ctx =>
+  test("choose in function") {
     val clause = fun1(IntegerLiteral(-1)) === IntegerLiteral(10)
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("choose in function and arguments") { implicit ctx =>
+  test("choose in function and arguments") {
     val clause = fun1(choose("v" :: IntegerType())(_ < IntegerLiteral(0))) === IntegerLiteral(10)
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("choose in callee function") { implicit ctx =>
+  test("choose in callee function") {
     val clause = fun2(IntegerLiteral(1), IntegerLiteral(-1)) === IntegerLiteral(10) &&
       fun2(IntegerLiteral(-1), IntegerLiteral(0)) === IntegerLiteral(2)
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("choose in parametric function") { implicit ctx =>
+  test("choose in parametric function") {
     val clause = fun3(IntegerType())(IntegerLiteral(1), E(true)) === IntegerLiteral(10) &&
       fun3(BooleanType())(E(true), E(true)) === E(false)
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("choose in recursive function") { implicit ctx =>
+  test("choose in recursive function") {
     val clause = fun4(IntegerLiteral(2), IntegerLiteral(1)) === IntegerLiteral(10)
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
 
@@ -107,12 +107,12 @@ class ChooseSuite extends SolvingTestSuite {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause3).isUNSAT)
   }
 
-  test("dependent choose doesn't feel lucky") { ctx0 =>
+  test("dependent choose doesn't feel lucky") { ctx0 ?=>
     val clause = let("x" :: IntegerType(), fun5(IntegerLiteral(0))) { x =>
       fun3(IntegerType())(IntegerLiteral(0), E(true)) === IntegerLiteral(0)
     }
 
-    implicit val ctx = ctx0.withOpts(optFeelingLucky(true), optCheckModels(false))
+    given inox.Context = ctx0.withOpts(optFeelingLucky(true), optCheckModels(false))
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isUNSAT)
   }
 }

--- a/src/it/scala/inox/solvers/unrolling/FunctionEqualitySuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/FunctionEqualitySuite.scala
@@ -30,7 +30,7 @@ class FunctionEqualitySuite extends SolvingTestSuite with DatastructureUtils {
 
   val program = InoxProgram(symbols)
 
-  test("simple theorem") { implicit ctx =>
+  test("simple theorem") {
     val clause = let(
       "states" :: T(mmapID)(IntegerType(), IntegerType() =>: IntegerType()),
       C(mmapConsID)(IntegerType(), IntegerType() =>: IntegerType())(\("i" :: IntegerType())(i => C(someID)(IntegerType() =>: IntegerType())(\("x" :: IntegerType())(x => IntegerLiteral(0)))))
@@ -39,7 +39,7 @@ class FunctionEqualitySuite extends SolvingTestSuite with DatastructureUtils {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(Not(clause)).isSAT)
   }
 
-  test("possible equality 1") { implicit ctx =>
+  test("possible equality 1") {
     val f = ("f" :: (IntegerType() =>: IntegerType())).toVariable
     val g = ("g" :: (IntegerType() =>: IntegerType())).toVariable
     val clause = f === (\("x" :: IntegerType())(x => g(x)))
@@ -47,7 +47,7 @@ class FunctionEqualitySuite extends SolvingTestSuite with DatastructureUtils {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("possible equality 2") { implicit ctx =>
+  test("possible equality 2") {
     val f = ("f" :: (IntegerType() =>: IntegerType())).toVariable
     val g = ("g" :: (IntegerType() =>: IntegerType())).toVariable
     val clause = g === (\("x" :: IntegerType())(x => f(x)))
@@ -55,14 +55,14 @@ class FunctionEqualitySuite extends SolvingTestSuite with DatastructureUtils {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("impossible equality 1") { implicit ctx =>
+  test("impossible equality 1") {
     val f = ("f" :: (IntegerType() =>: IntegerType())).toVariable
     val clause = f === (\("x" :: IntegerType())(x => f(x)))
 
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isUNSAT)
   }
 
-  test("impossible equality 2") { implicit ctx =>
+  test("impossible equality 2") {
     val f = ("f" :: (IntegerType() =>: IntegerType())).toVariable
     val g = ("g" :: (IntegerType() =>: IntegerType())).toVariable
     val clause = f === (\("x" :: IntegerType())(x => g(x))) && g === (\("x" :: IntegerType())(x => f(x)))

--- a/src/it/scala/inox/solvers/unrolling/InductiveUnrollingSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/InductiveUnrollingSuite.scala
@@ -111,18 +111,18 @@ class InductiveUnrollingSuite extends SolvingTestSuite with DatastructureUtils {
       let("res" :: T(T(listID)(aT), T(listID)(aT)), if_ (l is consID) {
         let("ptl" :: T(T(listID)(aT), T(listID)(aT)), E(partitionID)(aT)(l.getField(tail), p)) { ptl =>
           if_ (p(l.getField(head))) {
-            E(C(consID)(aT)(l.getField(head), ptl._1), ptl._2)
+            E(C(consID)(aT)(l.getField(head), ptl._ts1), ptl._ts2)
           } else_ {
-            E(ptl._1, C(consID)(aT)(l.getField(head), ptl._2))
+            E(ptl._ts1, C(consID)(aT)(l.getField(head), ptl._ts2))
           }
         }
       } else_ {
         E(l, l)
       }) { res =>
         Assume(
-          E(forallID)(aT)(res._1, p) &&
-          E(forallID)(aT)(res._2, \("x" :: aT)(x => !p(x))) &&
-          E(contentID)(aT)(l) === E(contentID)(aT)(res._1) ++ E(contentID)(aT)(res._2),
+          E(forallID)(aT)(res._ts1, p) &&
+          E(forallID)(aT)(res._ts2, \("x" :: aT)(x => !p(x))) &&
+          E(contentID)(aT)(l) === E(contentID)(aT)(res._ts1) ++ E(contentID)(aT)(res._ts2),
           res)
       }
     })
@@ -133,10 +133,10 @@ class InductiveUnrollingSuite extends SolvingTestSuite with DatastructureUtils {
       let("res" :: T(listID)(aT), if_ (l is consID) {
         let("part" :: T(T(listID)(aT), T(listID)(aT)),
           E(partitionID)(aT)(l.getField(tail), \("x" :: aT)(x => lt(x, l.getField(head))))) { part =>
-        let("less" :: T(listID)(aT), E(sortID)(aT)(part._1, lt)) { less =>
-        let("more" :: T(listID)(aT), E(sortID)(aT)(part._2, lt)) { more =>
-          Assume(E(forallID)(aT)(part._1, \("x" :: aT)(x => lt(x, l.getField(head)))),
-          Assume(E(contentID)(aT)(part._1) === E(contentID)(aT)(less),
+        let("less" :: T(listID)(aT), E(sortID)(aT)(part._ts1, lt)) { less =>
+        let("more" :: T(listID)(aT), E(sortID)(aT)(part._ts2, lt)) { more =>
+          Assume(E(forallID)(aT)(part._ts1, \("x" :: aT)(x => lt(x, l.getField(head)))),
+          Assume(E(contentID)(aT)(part._ts1) === E(contentID)(aT)(less),
           Assume(E(forallID)(aT)(less, \("x" :: aT)(x => lt(x, l.getField(head)))),
             E(appendID)(aT)(less, C(consID)(aT)(l.getField(head), more))
           )))
@@ -154,14 +154,14 @@ class InductiveUnrollingSuite extends SolvingTestSuite with DatastructureUtils {
 
   val program = InoxProgram(symbols)
 
-  test("size(x) == 0 is satisfiable") { implicit ctx =>
+  test("size(x) == 0 is satisfiable") {
     val vd = "x" :: T(listID)(IntegerType())
     val clause = sizeFd(IntegerType())(vd.toVariable) === E(BigInt(0))
 
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("size(x) < 0 is unsatisfiable") { implicit ctx =>
+  test("size(x) < 0 is unsatisfiable") {
     val vd = "x" :: T(listID)(IntegerType())
     val clause = sizeFd(IntegerType())(vd.toVariable) < E(BigInt(0))
 
@@ -179,18 +179,18 @@ class InductiveUnrollingSuite extends SolvingTestSuite with DatastructureUtils {
     else Test
   }
 
-  test("flatMap is associative", filter(_, allowOpt = true)) { implicit ctx =>
+  test("flatMap is associative", filter(_, allowOpt = true)) {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(Not(associative.fullBody)).isUNSAT)
   }
 
-  test("sort preserves content 1", filter(_)) { implicit ctx =>
+  test("sort preserves content 1", filter(_)) {
     val (l,p) = ("l" :: T(listID)(IntegerType()), "p" :: ((IntegerType(), IntegerType()) =>: BooleanType()))
     val clause = E(contentID)(IntegerType())(E(sortID)(IntegerType())(l.toVariable, p.toVariable)) ===
       E(contentID)(IntegerType())(l.toVariable)
     assert(SimpleSolverAPI(program.getSolver).solveSAT(Not(clause)).isUNSAT)
   }
 
-  test("sort preserves content 2", filter(_, allowSelect = false)) { implicit ctx =>
+  test("sort preserves content 2", filter(_, allowSelect = false)) {
     import program._
     val clause = sort.fullBody match {
       case Let(res, body, Assume(pred, resVar)) if res.toVariable == resVar =>

--- a/src/it/scala/inox/solvers/unrolling/MapMergeSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/MapMergeSuite.scala
@@ -37,27 +37,27 @@ class MapMergeSuite extends SolvingTestSuite with DatastructureUtils {
   val symbols = baseSymbols
   val program = InoxProgram(symbols)
 
-  test("Finite model finding 1") { implicit ctx =>
+  test("Finite model finding 1") {
     val clause = Not(Equals(merged, FiniteMap(Seq.empty, dummyValue, keyT, valueT)))
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Finite model finding 2") { implicit ctx =>
+  test("Finite model finding 2") {
     val clause = Not(Equals(merged, map1))
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Finite model finding 3") { implicit ctx =>
+  test("Finite model finding 3") {
     val clause = Not(Equals(merged, map2))
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Empty mask") { implicit ctx =>
+  test("Empty mask") {
     val clause = Implies(Equals(mask, FiniteSet(Seq.empty, keyT)), Equals(merged, map2))
     assert(SimpleSolverAPI(program.getSolver).solveVALID(clause) contains true)
   }
 
-  test("Element in mask") { implicit ctx =>
+  test("Element in mask") {
     val clause = Implies(
       ElementOfSet(someKey, mask),
       Equals(MapApply(merged, someKey), MapApply(map1, someKey)))

--- a/src/it/scala/inox/solvers/unrolling/QuantifiersSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/QuantifiersSuite.scala
@@ -65,17 +65,17 @@ class QuantifiersSuite extends TestSuite {
 
   val program = InoxProgram(symbols)
 
-  test("Pair of associative ==> associative pair") { implicit ctx => 
+  test("Pair of associative ==> associative pair") {
     val (aT,bT) = (T("A"), T("B"))
     val Seq(f1,f2) = Seq("f1" :: ((aT, aT) =>: aT), "f2" :: ((bT, bT) =>: bT)).map(_.toVariable)
     val clause = isAssociative(aT)(f1) && isAssociative(bT)(f2) && !isAssociative(T(aT,bT)) {
-      \("p1" :: T(aT,bT), "p2" :: T(aT, bT))((p1,p2) => E(f1(p1._1,p2._1), f2(p1._2,p2._2)))
+      \("p1" :: T(aT,bT), "p2" :: T(aT, bT))((p1,p2) => E(f1(p1._ts1,p2._ts1), f2(p1._ts2,p2._ts2)))
     }
 
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isUNSAT)
   }
 
-  test("Commutative and rotate ==> associative") { implicit ctx =>
+  test("Commutative and rotate ==> associative") {
     val aT = T("A")
     val f = ("f" :: ((aT, aT) =>: aT)).toVariable
     val clause = isCommutative(aT)(f) && isRotate(aT)(f) && !isAssociative(aT)(f)
@@ -83,14 +83,14 @@ class QuantifiersSuite extends TestSuite {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isUNSAT)
   }
 
-  test("Commutative and rotate ==> associative (integer type)") { implicit ctx =>
+  test("Commutative and rotate ==> associative (integer type)") {
     val f = ("f" :: ((IntegerType(), IntegerType()) =>: IntegerType())).toVariable
     val clause = isCommutative(IntegerType())(f) && isRotate(IntegerType())(f) && !isAssociative(IntegerType())(f)
 
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isUNSAT)
   }
 
-  test("Associative =!=> commutative") { implicit ctx =>
+  test("Associative =!=> commutative") {
     val aT = T("A")
     val f = ("f" :: ((aT, aT) =>: aT)).toVariable
     val clause = isAssociative(aT)(f) && !isCommutative(aT)(f)
@@ -98,7 +98,7 @@ class QuantifiersSuite extends TestSuite {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Commutative =!=> associative") { implicit ctx =>
+  test("Commutative =!=> associative") {
     val aT = T("A")
     val f = ("f" :: ((aT, aT) =>: aT)).toVariable
     val clause = isCommutative(aT)(f) && !isAssociative(aT)(f)
@@ -106,11 +106,11 @@ class QuantifiersSuite extends TestSuite {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Commutative + idempotent satisfiable") { ctx0 =>
+  test("Commutative + idempotent satisfiable") { ctx0 ?=>
     // For this test, we do not check the generated model with the Princess solver as we
     // are not able to find a model that satisfies the idempotency requirement.
     // This is due to being unlucky in choosing a default value for the model of f.
-    implicit val ctx =
+    given ctx: inox.Context =
       if (isPrincess(ctx0)) ctx0.withOpts(optCheckModels(false))
       else ctx0
     val f = ("f" :: ((IntegerType(), IntegerType()) =>: IntegerType())).toVariable
@@ -121,7 +121,7 @@ class QuantifiersSuite extends TestSuite {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Unification is unsatisfiable") { implicit ctx =>
+  test("Unification is unsatisfiable") {
     val aT = T("A")
     val f = ("f" :: ((aT, aT) =>: aT)).toVariable
     val clause = forall("x" :: aT, "y" :: aT)((x,y) => !(f(x,y) === f(y,x)))

--- a/src/it/scala/inox/solvers/unrolling/SetBagMapSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/SetBagMapSuite.scala
@@ -41,21 +41,21 @@ class SetBagMapSuite extends SolvingTestSuite with DatastructureUtils {
   val s2 = ("s" :: SetType(intRefinement)).toVariable
   val s3 = ("s" :: SetType(emptyType)).toVariable
 
-  test("Non-empty set") { implicit ctx =>
+  test("Non-empty set") {
     val clause = Not(Equals(s1, FiniteSet(Seq.empty, IntegerType())))
     val SatWithModel(model) = SimpleSolverAPI(program.getSolver).solveSAT(clause)
     val FiniteSet(value1, _) = model.vars(s1.toVal)
     assert(!value1.isEmpty)
   }
 
-  test("Non-empty set with refinement") { implicit ctx =>
+  test("Non-empty set with refinement") {
     val clause = Not(Equals(s2, FiniteSet(Seq.empty, IntegerType())))
     val SatWithModel(model) = SimpleSolverAPI(program.getSolver).solveSAT(clause)
     val FiniteSet(Seq(IntegerLiteral(value2)), _) = model.vars(s2.toVal)
     assert(value2 > 2000)
   }
 
-  test("Sets with empty base type are empty") { implicit ctx =>
+  test("Sets with empty base type are empty") {
     val clause = Equals(s3, FiniteSet(Seq.empty, IntegerType()))
     val result = SimpleSolverAPI(program.getSolver).solveVALID(clause)
     assert(result == Some(true))
@@ -71,21 +71,21 @@ class SetBagMapSuite extends SolvingTestSuite with DatastructureUtils {
   val y3 = "y" :: IntegerType()
   val bag3 = ("bag" :: BagType(emptyType)).toVariable
 
-  test("Non-empty bag") { implicit ctx =>
+  test("Non-empty bag") {
     val clause = Not(Equals(bag1, FiniteBag(Seq.empty, IntegerType())))
     val SatWithModel(model) = SimpleSolverAPI(program.getSolver).solveSAT(clause)
     val FiniteBag(value1, _) = model.vars(bag1.toVal)
     assert(!value1.isEmpty)
   }
 
-  test("Non-empty bag with refinement") { implicit ctx =>
+  test("Non-empty bag with refinement") {
     val clause = Not(Equals(bag2, FiniteBag(Seq.empty, IntegerType())))
     val SatWithModel(model) = SimpleSolverAPI(program.getSolver).solveSAT(clause)
     val FiniteBag(Seq((IntegerLiteral(value2), _)), _) = model.vars(bag2.toVal)
     assert(value2 > 2000)
   }
 
-  test("Bags with empty base type are empty") { implicit ctx =>
+  test("Bags with empty base type are empty") {
     val clause = Equals(bag3, FiniteBag(Seq.empty, IntegerType()))
     val result = SimpleSolverAPI(program.getSolver).solveVALID(clause)
     assert(result == Some(true))
@@ -97,20 +97,20 @@ class SetBagMapSuite extends SolvingTestSuite with DatastructureUtils {
   val map2 = ("map" :: MapType(emptyType, IntegerType())).toVariable
   val map3 = ("map" :: MapType(IntegerType(), emptyType)).toVariable
 
-  test("Maps with refinement types exist") { implicit ctx =>
+  test("Maps with refinement types exist") {
     val clause = Equals(map1, map1)
     val SatWithModel(model) = SimpleSolverAPI(program.getSolver).solveSAT(clause)
     val FiniteMap(_, IntegerLiteral(value), _, _) = model.vars(map1.toVal)
     assert(value > 2000)
   }
 
-  test("Maps with empty key type exist") { implicit ctx =>
+  test("Maps with empty key type exist") {
     val clause = Equals(map2, map2)
     val result = SimpleSolverAPI(program.getSolver).solveSAT(clause)
     assert(result.isSAT)
   }
 
-  test("Maps with empty value type don't exist") { implicit ctx =>
+  test("Maps with empty value type don't exist") {
     val clause = Equals(map3, map3)
     val result = SimpleSolverAPI(program.getSolver).solveSAT(clause)
     assert(!result.isSAT)

--- a/src/it/scala/inox/solvers/unrolling/SimpleUnrollingSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/SimpleUnrollingSuite.scala
@@ -42,9 +42,9 @@ class SimpleUnrollingSuite extends SolvingTestSuite {
 
   val program = InoxProgram(symbols)
   import program._
-  import program.symbols._
+  import program.symbols.{given, _}
 
-  test("size(x) > 0 is satisfiable") { implicit ctx =>
+  test("size(x) > 0 is satisfiable") {
     val vd: ValDef = "x" :: T(listID)(IntegerType())
     val clause = sizeFd(IntegerType())(vd.toVariable) > E(BigInt(0))
 
@@ -62,7 +62,7 @@ class SimpleUnrollingSuite extends SolvingTestSuite {
     }
   }
 
-  test("size(x) == 0 is satisfiable") { implicit ctx =>
+  test("size(x) == 0 is satisfiable") {
     val tp = TypeParameter.fresh("A")
     val vd: ValDef = "x" :: T(listID)(tp)
     val clause = sizeFd(tp)(vd.toVariable) === E(BigInt(0))
@@ -81,14 +81,14 @@ class SimpleUnrollingSuite extends SolvingTestSuite {
     }
   }
 
-  test("size(x) < 0 is not satisfiable (unknown)") { implicit ctx =>
+  test("size(x) < 0 is not satisfiable (unknown)") {
     val vd: ValDef = "x" :: T(listID)(IntegerType())
     val clause = sizeFd(IntegerType())(vd.toVariable) < E(BigInt(0))
 
     assert(!SimpleSolverAPI(program.getSolver.withTimeout(100)).solveSAT(clause).isSAT)
   }
 
-  test("size(x) > size(y) is satisfiable") { implicit ctx =>
+  test("size(x) > size(y) is satisfiable") {
     val x: ValDef = "x" :: T(listID)(IntegerType())
     val y: ValDef = "y" :: T(listID)(IntegerType())
     val clause = sizeFd(IntegerType())(x.toVariable) > sizeFd(IntegerType())(y.toVariable)
@@ -96,7 +96,7 @@ class SimpleUnrollingSuite extends SolvingTestSuite {
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("simple configuration is sound with quantifiers") { implicit ctx =>
+  test("simple configuration is sound with quantifiers") {
     val factory = program.getSolver
     val c = Variable.fresh("c", IntegerType())
     val x = Variable.fresh("x", IntegerType())

--- a/src/it/scala/inox/solvers/unrolling/StringSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/StringSuite.scala
@@ -23,41 +23,41 @@ class StringSuite extends SolvingTestSuite {
 
   val program = InoxProgram(NoSymbols)
 
-  test("Empty string model") { implicit ctx =>
+  test("Empty string model") {
     val v = Variable.fresh("v", StringType())
     val clause = Equals(v, StringLiteral(""))
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Non-empty string model") { implicit ctx =>
+  test("Non-empty string model") {
     val v = Variable.fresh("v", StringType())
     val clause = Not(Equals(v, StringLiteral("")))
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Ground equality") { implicit ctx =>
+  test("Ground equality") {
     val clause = Equals(StringLiteral(""), StringLiteral(""))
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Ground dis-equality") { implicit ctx =>
+  test("Ground dis-equality") {
     val clause = Not(Equals(StringLiteral(""), StringLiteral("")))
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isUNSAT)
   }
 
-  test("Positive length") { implicit ctx =>
+  test("Positive length") {
     val v = Variable.fresh("v", StringType())
     val clause = GreaterThan(StringLength(v), IntegerLiteral(BigInt(0)))
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Non-ASCII string encoding") { implicit ctx =>
+  test("Non-ASCII string encoding") {
     val v = Variable.fresh("v", StringType())
     val clause = Equals(v, StringLiteral("abéà"))
     assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
   }
 
-  test("Non-ASCII string length") { implicit ctx =>
+  test("Non-ASCII string length") {
     val v = Variable.fresh("v", IntegerType())
     val clause = Equals(v, StringLength(StringLiteral("abéà")))
     SimpleSolverAPI(program.getSolver).solveSAT(clause) match {
@@ -68,7 +68,7 @@ class StringSuite extends SolvingTestSuite {
     }
   }
 
-  test("String with newline") { implicit ctx =>
+  test("String with newline") {
     val v = Variable.fresh("r", StringType())
     val clause = Equals(v, StringLiteral("\n"))
     SimpleSolverAPI(program.getSolver).solveSAT(clause) match {

--- a/src/it/scala/inox/tip/TipPrintingSuite.scala
+++ b/src/it/scala/inox/tip/TipPrintingSuite.scala
@@ -15,7 +15,7 @@ class TipPrintingSuite extends AnyFunSuite with ResourceUtils {
   }
 
   private def checkScript(program: InoxProgram, expr: Expr): Unit = {
-    import program.symbols
+    import program.symbols.{given, _}
     symbols.ensureWellFormed
 
     assert(expr.isTyped)

--- a/src/it/scala/inox/tip/TipSerializationSuite.scala
+++ b/src/it/scala/inox/tip/TipSerializationSuite.scala
@@ -25,7 +25,7 @@ class TipSerializationSuite extends AnyFunSpec with ResourceUtils {
     program: Program { val trees: inox.trees.type },
     expr: Expr
   ) = {
-    import serializer._
+    import serializer.{given, _}
 
     val out = new java.io.ByteArrayOutputStream
     serializer.serialize(program.symbols, out)

--- a/src/it/scala/inox/tip/TipTestSuite.scala
+++ b/src/it/scala/inox/tip/TipTestSuite.scala
@@ -67,7 +67,7 @@ class TipTestSuite extends TestSuite with ResourceUtils {
     }
 
   for (file <- resourceFiles("regression/tip/SAT", _.endsWith(".tip"))) {
-    test(s"SAT - ${file.getName}", ignoreSAT(_, file)) { implicit ctx =>
+    test(s"SAT - ${file.getName}", ignoreSAT(_, file)) {
       for ((program, expr) <- Parser(file).parseScript) {
         assert(SimpleSolverAPI(program.getSolver).solveSAT(expr).isSAT)
       }
@@ -75,7 +75,7 @@ class TipTestSuite extends TestSuite with ResourceUtils {
   }
 
   for (file <- resourceFiles("regression/tip/UNSAT", _.endsWith(".tip"))) {
-    test(s"UNSAT - ${file.getName}", ignoreUNSAT(_, file)) { implicit ctx =>
+    test(s"UNSAT - ${file.getName}", ignoreUNSAT(_, file)) {
       for ((program, expr) <- Parser(file).parseScript) {
         assert(SimpleSolverAPI(program.getSolver).solveSAT(expr).isUNSAT)
       }
@@ -83,8 +83,8 @@ class TipTestSuite extends TestSuite with ResourceUtils {
   }
 
   for (file <- resourceFiles("regression/tip/UNKNOWN", _.endsWith(".tip"))) {
-    test(s"UNKNOWN - ${file.getName}", ignoreUNKNOWN(_, file)) { ctx0 =>
-      implicit val ctx = ctx0.copy(options = ctx0.options + optCheckModels(false))
+    test(s"UNKNOWN - ${file.getName}", ignoreUNKNOWN(_, file)) { ctx0 ?=>
+      given ctx: inox.Context = ctx0.copy(options = ctx0.options + optCheckModels(false))
       for ((program, expr) <- Parser(file).parseScript) {
         val api = SimpleSolverAPI(program.getSolver)
         val res = api.solveSAT(expr)

--- a/src/main/doc/tutorial.md
+++ b/src/main/doc/tutorial.md
@@ -17,14 +17,14 @@ However, Inox provides all the tools necessary to enable inductive reasoning, as
 Let us start by setting up some useful imports:
 
 ```scala mdoc:silent
-import inox._
+import inox.{given, _}
 import inox.trees._
 import inox.trees.dsl._
 import inox.solvers._
 ```
 
 The explanation is the following:
-- `inox._` imports [`InoxProgram` and many others](/src/main/scala/inox/package.scala#L19)
+- `inox.{given, _}` imports [`InoxProgram` and many others](/src/main/scala/inox/package.scala#L19)
 - `inox.trees._` imports the content of the default implementation [`trees`](/src/main/scala/inox/package.scala#L53) extending [`Trees`](/src/main/scala/inox/ast/Trees.scala#L10).
 - `inox.trees.dsl._` imports the [domain-specific-language helpers](/src/main/scala/inox/ast/DSL.scala#L20) to create [`trees`](/src/main/scala/inox/package.scala#L53) expressions.
 - `inox.solvers._` imports the [solvers](/src/main/scala/inox/solvers/package.scala#L8).
@@ -198,9 +198,9 @@ __Note__: Inox will assume the inductive invariant on the recursive call to `siz
 In order to verify the property, we get an instance of an Inox solver (see
 [Programs](/doc/API.md#programs) and [Solvers](/doc/API.md#solvers) for more details):
 ```scala mdoc:silent
-implicit val ctx: Context = Context.empty
+given ctx: Context = Context.empty
 val program = inox.Program(inox.trees)(symbols)
-val solver = program.getSolver.getNewSolver
+val solver = program.getSolver.getNewSolver()
 solver.assertCnstr(Not(prop))
 solver.check(SolverResponses.Simple) // Should return `Unsat`
 solver.free()

--- a/src/main/scala/inox/Context.scala
+++ b/src/main/scala/inox/Context.scala
@@ -14,7 +14,7 @@ case class Context(
   options: Options = Options(Seq()),
   timers: TimerStorage = TimerStorage()) {
 
-  implicit val implicitContext: this.type = this
+  given givenContext: this.type = this
 
   def withOpts(opts: OptionValue[_]*): Context = copy(options = options ++ opts)
 }

--- a/src/main/scala/inox/Options.scala
+++ b/src/main/scala/inox/Options.scala
@@ -24,7 +24,7 @@ abstract class OptionDef[A] {
 
   def formatDefault: String = default.toString
 
-  private def parseValue(s: String)(implicit reporter: Reporter): A = {
+  private def parseValue(s: String)(using reporter: Reporter): A = {
     parser(s).getOrElse(
       reporter.fatalError(
         s"Invalid option usage: --$name=$s\n" +
@@ -33,7 +33,7 @@ abstract class OptionDef[A] {
     )
   }
 
-  def parse(s: String)(implicit reporter: Reporter): OptionValue[A] =
+  def parse(s: String)(using Reporter): OptionValue[A] =
     OptionValue(this)(parseValue(s))
 
   def withDefaultValue: OptionValue[A] =
@@ -190,7 +190,7 @@ object OptionsHelpers {
 case class Options(options: Seq[OptionValue[_]]) {
 
   def findOption[A: ClassTag](optDef: OptionDef[A]): Option[A] = options.collectFirst {
-    case OptionValue(`optDef`, value: A) => value
+    case OptionValue(`optDef`, value) => value.asInstanceOf[A]
   }
 
   def findOptionOrDefault[A: ClassTag](optDef: OptionDef[A]): A = findOption(optDef).getOrElse(optDef.default)

--- a/src/main/scala/inox/Reporter.scala
+++ b/src/main/scala/inox/Reporter.scala
@@ -85,25 +85,22 @@ abstract class Reporter(val debugSections: Set[DebugSection]) {
     }
   }
 
-  def isDebugEnabled(implicit section: DebugSection): Boolean = debugSections(section)
+  def isDebugEnabled(using section: DebugSection): Boolean = debugSections(section)
 
-  def ifDebug(pos: Position, body: (Any => Unit) => Any)(implicit section: DebugSection) = {
+  def ifDebug(pos: Position, body: (Any => Unit) => Any)(using section: DebugSection) = {
     if (isDebugEnabled) {
       body( { (msg: Any) => emit(account(Message(DEBUG(section), pos, msg))) } )
     }
   }
 
   def whenDebug(pos: Position, section: DebugSection)(body: (Any => Unit) => Any): Unit = {
-    if (isDebugEnabled(section)) {
+    if (isDebugEnabled(using section)) {
       body( { (msg: Any) => emit(account(Message(DEBUG(section), pos, msg))) } )
     }
   }
 
-  def debug(pos: Position, msg: => Any)(implicit section: DebugSection): Unit = {
-    ifDebug(pos, debug =>
-      debug(msg)
-    )(section)
-  }
+  def debug(pos: Position, msg: => Any)(using DebugSection): Unit =
+    ifDebug(pos, debug => debug(msg))
 
   // No-position alternatives
   final def info(msg: Any): Unit          = info(NoPosition, msg)
@@ -121,20 +118,20 @@ abstract class Reporter(val debugSections: Set[DebugSection]) {
 
   final def internalAssertion(cond : Boolean, msg: Any) : Unit = internalAssertion(cond,NoPosition, msg)
 
-  final def debug(msg: => Any)(implicit section: DebugSection): Unit = debug(NoPosition, msg)
-  final def ifDebug(body: (Any => Unit) => Any)(implicit section: DebugSection): Unit =
+  final def debug(msg: => Any)(using DebugSection): Unit = debug(NoPosition, msg)
+  final def ifDebug(body: (Any => Unit) => Any)(using DebugSection): Unit =
     ifDebug(NoPosition, body)
   final def whenDebug(section: DebugSection)(body: (Any => Unit) => Any): Unit =
     whenDebug(NoPosition, section)(body)
 
-  final def debug(pos: Position, msg: => Any, e: Throwable)(implicit section: DebugSection): Unit = {
-    if (isDebugEnabled(section)) {
+  final def debug(pos: Position, msg: => Any, e: Throwable)(using section: DebugSection): Unit = {
+    if (isDebugEnabled) {
       debug(pos, msg)
       logTrace(DEBUG(section), e)
     }
   }
 
-  final def debug(e: Throwable)(implicit section: DebugSection): Unit =
+  final def debug(e: Throwable)(using DebugSection): Unit =
     debug(NoPosition, e.getMessage, e)
 
   private def logTrace(severity: Severity, e: Throwable): Unit = synchronized {

--- a/src/main/scala/inox/Semantics.scala
+++ b/src/main/scala/inox/Semantics.scala
@@ -25,12 +25,12 @@ trait Semantics { self =>
     val program: self.program.type
   }
 
-  def getSolver(implicit ctx: Context): solvers.SolverFactory {
+  def getSolver(using ctx: Context): solvers.SolverFactory {
     val program: self.program.type
     type S <: solvers.combinators.TimeoutSolver { val program: self.program.type }
   } = solverCache.cached(ctx, createSolver(ctx))
 
-  def getEvaluator(implicit ctx: Context): evaluators.DeterministicEvaluator {
+  def getEvaluator(using ctx: Context): evaluators.DeterministicEvaluator {
     val program: self.program.type
   } = evaluatorCache.cached(ctx, createEvaluator(ctx))
 }

--- a/src/main/scala/inox/ast/CallGraph.scala
+++ b/src/main/scala/inox/ast/CallGraph.scala
@@ -18,6 +18,8 @@ trait CallGraph {
     protected def register(id: Identifier): Unit = ids += id
     def result: Set[Identifier] = ids
   }
+  // Used as a default implementation for the trait Collector
+  protected class ConcreteCollector extends ConcreteSelfTreeTraverser with Collector
 
   protected trait FunctionCollector extends Collector {
     override def traverse(expr: Expr): Unit = expr match {
@@ -28,8 +30,10 @@ trait CallGraph {
         super.traverse(expr)
     }
   }
+  // Used as a default implementation for the trait FunctionCollector
+  protected class ConcreteFunctionCollector extends ConcreteSelfTreeTraverser with FunctionCollector
 
-  protected def getFunctionCollector: Collector = new FunctionCollector {}
+  protected def getFunctionCollector: Collector = new ConcreteFunctionCollector
 
   private def collectCalls(fd: FunDef): Set[Identifier] = {
     val collector = getFunctionCollector
@@ -56,96 +60,75 @@ trait CallGraph {
 
   def allCalls = callGraph.E.map(e => e._1 -> e._2)
 
-  def isRecursive(id: Identifier): Boolean = {
+  def isRecursive(id: Identifier): Boolean =
     callGraph.transitiveSucc(id) contains id
-  }
 
-  def isSelfRecursive(id: Identifier): Boolean = {
+  def isSelfRecursive(id: Identifier): Boolean =
     callGraph.succ(id) contains id
-  }
 
-  def calls(from: Identifier, to: Identifier): Boolean = {
+  def calls(from: Identifier, to: Identifier): Boolean =
     callGraph.E contains SimpleEdge(from, to)
-  }
 
-  def callers(to: Identifier): Set[Identifier] = {
+  def callers(to: Identifier): Set[Identifier] =
     callGraph.pred(to)
-  }
 
-  def callers(to: FunDef): Set[FunDef] = {
+  def callers(to: FunDef): Set[FunDef] =
     callers(to.id).map(symbols.getFunction(_))
-  }
 
-  def callers(tos: Set[Identifier]): Set[Identifier] = {
+  def callers(tos: Set[Identifier]): Set[Identifier] =
     tos.flatMap(callers)
-  }
 
-  def callers(tos: Set[FunDef])(implicit dummy: DummyImplicit): Set[FunDef] = {
+  def callers(tos: Set[FunDef])(using DummyImplicit): Set[FunDef] =
     tos.flatMap(callers)
-  }
 
-  def callees(from: Identifier): Set[Identifier] = {
+  def callees(from: Identifier): Set[Identifier] =
     callGraph.succ(from)
-  }
 
-  def callees(from: FunDef): Set[FunDef] = {
+  def callees(from: FunDef): Set[FunDef] =
     callees(from.id).map(symbols.getFunction(_))
-  }
 
-  def callees(froms: Set[Identifier]): Set[Identifier] = {
+  def callees(froms: Set[Identifier]): Set[Identifier] =
     froms.flatMap(callees)
-  }
 
-  def callees(froms: Set[FunDef])(implicit dummy: DummyImplicit): Set[FunDef] = {
+  def callees(froms: Set[FunDef])(using DummyImplicit): Set[FunDef] =
     froms.flatMap(callees)
-  }
 
-  def transitiveCallers(to: Identifier): Set[Identifier] = {
+  def transitiveCallers(to: Identifier): Set[Identifier] =
     callGraph.transitivePred(to)
-  }
 
-  def transitiveCallers(to: FunDef): Set[FunDef] = {
+  def transitiveCallers(to: FunDef): Set[FunDef] =
     transitiveCallers(to.id).map(symbols.getFunction(_))
-  }
 
-  def transitiveCallers(tos: Set[Identifier]): Set[Identifier] = {
+  def transitiveCallers(tos: Set[Identifier]): Set[Identifier] =
     tos.flatMap(transitiveCallers)
-  }
 
-  def transitiveCallers(tos: Set[FunDef])(implicit dummy: DummyImplicit): Set[FunDef] = {
+  def transitiveCallers(tos: Set[FunDef])(using DummyImplicit): Set[FunDef] =
     tos.flatMap(transitiveCallers)
-  }
 
-  def transitiveCallees(from: Identifier): Set[Identifier] = {
+  def transitiveCallees(from: Identifier): Set[Identifier] =
     callGraph.transitiveSucc(from)
-  }
 
-  def transitiveCallees(from: FunDef): Set[FunDef] = {
+  def transitiveCallees(from: FunDef): Set[FunDef] =
     transitiveCallees(from.id).map(symbols.getFunction(_))
-  }
 
-  def transitiveCallees(froms: Set[Identifier]): Set[Identifier] = {
+  def transitiveCallees(froms: Set[Identifier]): Set[Identifier] =
     froms.flatMap(transitiveCallees)
-  }
 
-  def transitiveCallees(froms: Set[FunDef])(implicit dummy: DummyImplicit): Set[FunDef] = {
+  def transitiveCallees(froms: Set[FunDef])(using DummyImplicit): Set[FunDef] =
     froms.flatMap(transitiveCallees)
-  }
 
-  def transitivelyCalls(from: Identifier, to: Identifier): Boolean = {
+  def transitivelyCalls(from: Identifier, to: Identifier): Boolean =
     callGraph.transitiveSucc(from) contains to
-  }
 
-  def transitivelyCalls(from: FunDef, to: FunDef): Boolean = {
+  def transitivelyCalls(from: FunDef, to: FunDef): Boolean =
     transitivelyCalls(from.id, to.id)
-  }
 
   @inline def sccs: DiGraph[Set[Identifier], SimpleEdge[Set[Identifier]]] = _sccs.get
   private[this] val _sccs: Lazy[DiGraph[Set[Identifier], SimpleEdge[Set[Identifier]]]] =
     Lazy(callGraph.stronglyConnectedComponents)
 
   object CallGraphOrderings {
-    implicit object componentOrdering extends Ordering[Set[FunDef]] {
+    given componentOrdering: Ordering[Set[FunDef]] with
       private val components = sccs.topSort.zipWithIndex.map {
         case (ids, i) => ids.map(symbols.getFunction(_)) -> i
       }.toMap.withDefaultValue(-1)
@@ -153,9 +136,8 @@ trait CallGraph {
       def compare(a: Set[FunDef], b: Set[FunDef]): Int = {
         components(a).compare(components(b))
       }
-    }
 
-    implicit object functionOrdering extends Ordering[FunDef] {
+    given functionOrdering: Ordering[FunDef] with
       private val functionToComponent = sccs.N.flatMap { ids =>
         val fds = ids.map(symbols.getFunction(_))
         fds.map(_ -> fds)
@@ -168,6 +150,5 @@ trait CallGraph {
         else if (c2.isEmpty) +1
         else componentOrdering.compare(c1, c2)
       }
-    }
   }
 }

--- a/src/main/scala/inox/ast/DependencyGraph.scala
+++ b/src/main/scala/inox/ast/DependencyGraph.scala
@@ -6,7 +6,7 @@ package ast
 import utils.Lazy
 import utils.Graphs._
 
-trait DependencyGraph extends CallGraph {
+trait DependencyGraph extends CallGraph { self =>
   import trees._
 
   protected trait SortCollector extends Collector {
@@ -26,8 +26,12 @@ trait DependencyGraph extends CallGraph {
         super.traverse(expr)
     }
   }
+  // Used as a default implementation for the trait SortCollector
+  protected class ConcreteSortCollector(override val trees: self.trees.type) extends SortCollector {
+    def this() = this(self.trees)
+  }
 
-  protected def getSortCollector: Collector = new SortCollector {}
+  protected def getSortCollector: Collector = new ConcreteSortCollector
 
   private def collectSorts(fd: FunDef): Set[Identifier] = {
     val collector = getSortCollector

--- a/src/main/scala/inox/ast/GenTreeOps.scala
+++ b/src/main/scala/inox/ast/GenTreeOps.scala
@@ -197,7 +197,7 @@ trait GenTreeOps { self =>
 
     if (applyRec) {
       // Apply f as long as it returns Some()
-      fixpoint { e : Target => f(e) getOrElse e } (newV)
+      fixpoint { (e : Target) => f(e) getOrElse e } (newV)
     } else {
       f(newV) getOrElse newV
     }
@@ -283,7 +283,7 @@ trait GenTreeOps { self =>
       val (newV, newCtx) = {
         if(applyRec) {
           var ctx = context
-          val finalV = fixpoint{ e: Source => {
+          val finalV = fixpoint{ (e: Source) => {
             val res = f(e, ctx)
             ctx = res._2
             res._1.getOrElse(e)
@@ -389,11 +389,11 @@ trait GenTreeOps { self =>
 
   object Same {
     def unapply(tt: (Source, Target))
-               (implicit ev1: Source =:= Target, ev2: Target =:= Source): Option[(Source, Target)] = {
+               (using ev1: Source =:= Target, ev2: Target =:= Source): Option[(Source, Target)] = {
       val Deconstructor(es1, recons1) = tt._1
       val Deconstructor(es2, recons2) = ev2(tt._2)
 
-      if (es1.size == es2.size && scala.util.Try(recons2(es1.map(ev1))).toOption == Some(ev2(tt._1))) {
+      if (es1.size == es2.size && scala.util.Try(recons2(es1.map(ev1))).toOption == Some(ev1(tt._1))) {
         Some(tt)
       } else {
         None

--- a/src/main/scala/inox/ast/Identifier.scala
+++ b/src/main/scala/inox/ast/Identifier.scala
@@ -33,14 +33,14 @@ class Identifier (
   def freshen: Identifier = FreshIdentifier(name, alwaysShowUniqueID)
 
   override def compare(that: Identifier): Int = {
-    val ord = implicitly[Ordering[(String, Int, Int)]]
+    val ord = summon[Ordering[(String, Int, Int)]]
     ord.compare(
       (this.name, this.id, this.globalId),
       (that.name, that.id, that.globalId)
     )
   }
 
-  def asString(implicit opts: Trees#PrinterOptions): String = {
+  def asString(using opts: Trees#PrinterOptions): String = {
     if (opts.printUniqueIds) uniqueName else toString
   }
 }

--- a/src/main/scala/inox/ast/SimpleSymbols.scala
+++ b/src/main/scala/inox/ast/SimpleSymbols.scala
@@ -5,18 +5,19 @@ package ast
 
 trait SimpleSymbols { self: Trees =>
 
-  override val NoSymbols = Symbols(Map.empty, Map.empty)
+  override val NoSymbols = mkSymbols(Map.empty, Map.empty)
 
-  val Symbols: (Map[Identifier, FunDef], Map[Identifier, ADTSort]) => Symbols
+  def mkSymbols(functions: Map[Identifier, FunDef], sorts: Map[Identifier, ADTSort]): Symbols
 
-  abstract class SimpleSymbols extends AbstractSymbols { self: Symbols =>
+  abstract class SimpleSymbols(override val trees: self.type) extends AbstractSymbols { self0: Symbols =>
+    def this() = this(self)
 
-    override def withFunctions(functions: Seq[FunDef]): Symbols = Symbols(
+    override def withFunctions(functions: Seq[FunDef]): Symbols = mkSymbols(
       this.functions ++ functions.map(fd => fd.id -> fd),
       this.sorts
     )
 
-    override def withSorts(sorts: Seq[ADTSort]): Symbols = Symbols(
+    override def withSorts(sorts: Seq[ADTSort]): Symbols = mkSymbols(
       this.functions,
       this.sorts ++ sorts.map(s => s.id -> s)
     )

--- a/src/main/scala/inox/ast/TreeOps.scala
+++ b/src/main/scala/inox/ast/TreeOps.scala
@@ -5,13 +5,16 @@ package ast
 trait TreeOps { self: Trees =>
 
   trait SelfTransformer extends transformers.Transformer {
-    val s: self.type = self
-    val t: self.type = self
+    // The only value that can be assigned to `s` and `t` is `self`, but that has to be
+    // done in a concrete class explicitly overriding `s` and `t`.
+    // Otherwise, we can run into initialization issue.
+    val s: self.type
+    val t: self.type
   }
 
   trait SelfTreeTransformer extends transformers.TreeTransformer {
-    val s: self.type = self
-    val t: self.type = self
+    val s: self.type
+    val t: self.type
   }
 
   trait IdentityTransformer extends SelfTransformer {
@@ -25,17 +28,49 @@ trait TreeOps { self: Trees =>
   trait IdentityTreeTransformer extends IdentityTransformer with transformers.TreeTransformer
 
   trait IdentitySymbolTransformer extends transformers.SymbolTransformer {
-    val s: self.type = self
-    val t: self.type = self
+    val s: self.type
+    val t: self.type
 
     override def transform(syms: s.Symbols): t.Symbols = syms
   }
 
   trait SelfTraverser extends transformers.Traverser {
-    val trees: self.type = self
+    val trees: self.type
   }
 
   trait SelfTreeTraverser extends transformers.TreeTraverser {
-    val trees: self.type = self
+    val trees: self.type
+  }
+
+  // Implementation of these traits as classes, as a conveniance when we want to create an anonymous transformer/traverser.
+
+  // As noted in SelfTransformer, we must override `s` and `t` to ensure correct initialization of fields
+  // in the parents that use `s` and `t`.
+  class ConcreteSelfTransformer(override val s: self.type, override val t: self.type) extends SelfTransformer {
+    def this() = this(self, self)
+  }
+
+  class ConcreteSelfTreeTransformer(override val s: self.type, override val t: self.type) extends SelfTreeTransformer {
+    def this() = this(self, self)
+  }
+
+  class ConcreteIdentityTransformer(override val s: self.type, override val t: self.type) extends IdentityTransformer {
+    def this() = this(self, self)
+  }
+
+  class ConcreteIdentityTreeTransformer(override val s: self.type, override val t: self.type) extends IdentityTreeTransformer {
+    def this() = this(self, self)
+  }
+
+  class ConcreteIdentitySymbolTransformer(override val s: self.type, override val t: self.type) extends IdentitySymbolTransformer {
+    def this() = this(self, self)
+  }
+
+  class ConcreteSelfTraverser(override val trees: self.type) extends SelfTraverser {
+    def this() = this(self)
+  }
+
+  class ConcreteSelfTreeTraverser(override val trees: self.type) extends SelfTreeTraverser {
+    def this() = this(self)
   }
 }

--- a/src/main/scala/inox/ast/TypeOps.scala
+++ b/src/main/scala/inox/ast/TypeOps.scala
@@ -12,20 +12,20 @@ trait TypeOps {
   protected val trees: Trees
   import trees._
 
-  protected implicit val symbols: Symbols
-  import symbols._
+  protected val symbols: Symbols
+  import symbols.{given, _}
 
   class TypeErrorException(msg: String, val obj: Expr, val pos: Position) extends Exception(msg)
 
   object TypeErrorException {
     def apply(obj: Expr, tpes: Seq[Type]): TypeErrorException =
       new TypeErrorException(
-        s"""Type error: $obj, expected ${tpes.mkString(" or ")}, 
+        s"""Type error: $obj, expected ${tpes.mkString(" or ")},
            |found ${obj.getType}
            |
            |Typing explanation:
-           |${explainTyping(obj)(new PrinterOptions())}""".stripMargin, 
-        obj, 
+           |${symbols.explainTyping(obj)(using new PrinterOptions())}""".stripMargin,
+        obj,
         obj.getPos
       )
 

--- a/src/main/scala/inox/evaluators/ContextualEvaluator.scala
+++ b/src/main/scala/inox/evaluators/ContextualEvaluator.scala
@@ -6,9 +6,10 @@ package evaluators
 object optMaxCalls extends IntOptionDef("max-calls", 50000, "<PosInt> | -1 (unbounded)")
 
 trait ContextualEvaluator extends Evaluator {
-  import context._
+  import context.{given, _}
   import program._
   import program.trees._
+  import program.symbols.{given, _}
 
   lazy val maxSteps: Int = options.findOptionOrDefault(optMaxCalls)
 
@@ -56,7 +57,7 @@ trait ContextualEvaluator extends Evaluator {
 
   def eval(ex: Expr, model: program.Model) = timers.evaluators.recursive.runtime.run {
     try {
-      EvaluationResults.Successful(e(ex)(initRC(model), initGC))
+      EvaluationResults.Successful(e(ex)(using initRC(model), initGC))
     } catch {
       case EvalError(msg) =>
         EvaluationResults.EvaluatorError(msg)
@@ -69,13 +70,13 @@ trait ContextualEvaluator extends Evaluator {
     }
   }
 
-  protected def e(expr: Expr)(implicit rctx: RC, gctx: GC): Value
+  protected def e(expr: Expr)(using rctx: RC, gctx: GC): Value
 
   def typeErrorMsg(tree: Expr, expected: Type): String = 
     s"""|Type error : expected ${expected.asString}, found ${tree.asString} of type ${tree.getType}.
         |
         |Type explanation:
-        |${symbols.explainTyping(tree)(new PrinterOptions())}
+        |${symbols.explainTyping(tree)(using new PrinterOptions())}
         """.stripMargin
 }
 

--- a/src/main/scala/inox/evaluators/EncodingEvaluator.scala
+++ b/src/main/scala/inox/evaluators/EncodingEvaluator.scala
@@ -3,16 +3,16 @@
 package inox
 package evaluators
 
-trait EncodingEvaluator extends DeterministicEvaluator { self =>
+class EncodingEvaluator(override val program: Program, override val context: Context)
+                       (val encoder: transformers.ProgramTransformer { val sourceProgram: program.type })
+                       (val underlying: DeterministicEvaluator { val program: encoder.targetProgram.type })
+  extends DeterministicEvaluator { self =>
   import program.trees._
 
-  protected val encoder: transformers.ProgramTransformer { val sourceProgram: program.type }
-
-  protected val underlying: DeterministicEvaluator {
-    val program: encoder.targetProgram.type
-  }
-
-  lazy val context = underlying.context
+  def this(program: Program,
+           encoder: transformers.ProgramTransformer { val sourceProgram: program.type },
+           underlying: DeterministicEvaluator { val program: encoder.targetProgram.type }) =
+    this(program, underlying.context)(encoder)(underlying)
 
   def eval(expr: Expr, model: program.Model): EvaluationResult = {
     val res = underlying.eval(encoder.encode(expr), model.encode(encoder))
@@ -29,11 +29,9 @@ object EncodingEvaluator {
   def apply(p: Program)
            (enc: transformers.ProgramTransformer { val sourceProgram: p.type })
            (ev: DeterministicEvaluator { val program: enc.targetProgram.type }) = {
-    new {
-      val program: p.type = p
-    } with EncodingEvaluator {
-      val encoder: enc.type = enc
-      val underlying = ev
-    }
+    class Impl(override val program: p.type,
+               override val encoder: enc.type,
+               override val underlying: ev.type) extends EncodingEvaluator(program, encoder, underlying)
+    new Impl(p, enc, ev)
   }
 }

--- a/src/main/scala/inox/evaluators/SolvingEvaluator.scala
+++ b/src/main/scala/inox/evaluators/SolvingEvaluator.scala
@@ -9,12 +9,13 @@ import solvers.combinators._
 import scala.collection.mutable.{Map => MutableMap}
 
 trait SolvingEvaluator extends Evaluator { self =>
-  import context._
+  import context.{given, _}
   import program._
   import program.trees._
-  import program.symbols._
+  import program.symbols.{given, _}
 
-  protected implicit val semantics: program.Semantics
+  protected val semantics: program.Semantics
+  given givenSemantics: semantics.type = semantics
 
   private object optForallCache extends OptionDef[MutableMap[Forall, Boolean]] {
     val parser = { (_: String) => throw FatalError("Unparsable option \"forallCache\"") }
@@ -75,7 +76,7 @@ trait SolvingEvaluator extends Evaluator { self =>
     BooleanLiteral(forallCache.getOrElse(forall, {
       import scala.language.existentials
       val sf = context.timers.evaluators.forall.run {
-        semantics.getSolver(context.withOpts(
+        semantics.getSolver(using context.withOpts(
           optSilentErrors(true),
           optCheckModels(false), // model is checked manually!! (see below)
           unrolling.optFeelingLucky(false),

--- a/src/main/scala/inox/package.scala
+++ b/src/main/scala/inox/package.scala
@@ -17,7 +17,7 @@ import scala.language.implicitConversions
   * [[inox.utils]]: Utility methods
   */
 package object inox {
-  implicit class BooleanToOption(cond: Boolean) {
+  extension (cond: Boolean) {
     def option[A](v: => A) = if (cond) Some(v) else None
   }
 
@@ -54,12 +54,17 @@ package object inox {
     case class Symbols(
       functions: Map[Identifier, FunDef],
       sorts: Map[Identifier, ADTSort]
-    ) extends SimpleSymbols
+    ) extends SimpleSymbols {
+      override val symbols: this.type = this
+    }
+
+    override def mkSymbols(functions: Map[Identifier, FunDef], sorts: Map[Identifier, ADTSort]): Symbols =
+      Symbols(functions, sorts)
 
     object printer extends ast.Printer { val trees: inox.trees.type = inox.trees }
   }
 
-  implicit val inoxSemantics: SemanticsProvider { val trees: inox.trees.type } = new SemanticsProvider {
+  val inoxSemantics: SemanticsProvider { val trees: inox.trees.type } = new SemanticsProvider {
     val trees: inox.trees.type = inox.trees
 
     def getSemantics(p: Program { val trees: inox.trees.type }): p.Semantics = new inox.Semantics { self =>
@@ -80,4 +85,5 @@ package object inox {
       } = evaluators.RecursiveEvaluator(self.program, ctx)
     }.asInstanceOf[p.Semantics]
   }
+  given givenInoxSemantics: inoxSemantics.type = inoxSemantics
 }

--- a/src/main/scala/inox/parsing/BuiltIns.scala
+++ b/src/main/scala/inox/parsing/BuiltIns.scala
@@ -5,7 +5,7 @@ package parsing
 
 trait BuiltIns {
 
-  lazy val bi = new DefaultBuiltIns {}
+  val bi = new DefaultBuiltIns {}
 
   trait BuiltInNames { 
 

--- a/src/main/scala/inox/parsing/ConstraintSolver.scala
+++ b/src/main/scala/inox/parsing/ConstraintSolver.scala
@@ -17,7 +17,7 @@ trait ConstraintSolvers { self: Elaborators =>
     object UnknownCollector {
       var unknowns = Set[Unknown]()
 
-      private val traverser = new SelfTreeTraverser {
+      private val traverser = new ConcreteSelfTreeTraverser {
         override def traverse(t: Type): Unit = {
           t match {
             case u: Unknown => unknowns += u
@@ -36,7 +36,7 @@ trait ConstraintSolvers { self: Elaborators =>
     class OccurChecker(u: Unknown) {
       var exists = false
 
-      val traverser = new SelfTreeTraverser {
+      val traverser = new ConcreteSelfTreeTraverser {
         override def traverse(t: Type): Unit = {
           t match {
             case u2: Unknown => {
@@ -206,7 +206,7 @@ trait ConstraintSolvers { self: Elaborators =>
             }
             if (n == 1) {
               val (sort, rest) = sorts.toSeq.head
-              val typeArgs = sort.tparams.map(x => Unknown.fresh(constraint.pos))
+              val typeArgs = sort.tparams.map(x => Unknown.fresh(using constraint.pos))
               val expectedType = ADTType(sort.id, typeArgs)
 
               remaining +:= Equal(a, expectedType)

--- a/src/main/scala/inox/parsing/DefinitionExtractor.scala
+++ b/src/main/scala/inox/parsing/DefinitionExtractor.scala
@@ -6,7 +6,7 @@ package parsing
 trait DefinitionExtractors { self: Extractors =>
 
   trait DefinitionExtractor { self0: Extractor =>
-
+    import symbols.given
     import DefinitionIR._
 
     def extract(fd: trees.FunDef, template: FunDef): Option[Match] = extract(

--- a/src/main/scala/inox/parsing/ExpressionDeconstructor.scala
+++ b/src/main/scala/inox/parsing/ExpressionDeconstructor.scala
@@ -6,8 +6,8 @@ package parsing
 trait ExpressionDeconstructors extends IRs {
 
   trait ExpressionDeconstructor {
-    implicit val symbols: trees.Symbols
-
+    val symbols: trees.Symbols
+    import symbols.given
     import ExprIR._
 
     object TupleField {
@@ -198,7 +198,7 @@ trait ExpressionDeconstructors extends IRs {
       def unapply(expr: Expression): Option[(Expression, Expression, (trees.Expr, trees.Expr) => trees.Expr, Option[Type])] = expr match {
         case SetUnionOperation(set1, set2, otpe) => Some((set1, set2, { (lhs: trees.Expr, rhs: trees.Expr) => trees.SetUnion(lhs, rhs) }, otpe))
         case SetIntersectionOperation(set1, set2, otpe) => Some((set1, set2, { (lhs: trees.Expr, rhs: trees.Expr) => trees.SetIntersection(lhs, rhs) }, otpe))
-        case SetUnionOperation(set1, set2, otpe) => Some((set1, set2, { (lhs: trees.Expr, rhs: trees.Expr) => trees.SetDifference(lhs, rhs) }, otpe))
+        case SetDifferenceOperation(set1, set2, otpe) => Some((set1, set2, { (lhs: trees.Expr, rhs: trees.Expr) => trees.SetDifference(lhs, rhs) }, otpe))
         case _ => None
       }
     }

--- a/src/main/scala/inox/parsing/ExpressionExtractor.scala
+++ b/src/main/scala/inox/parsing/ExpressionExtractor.scala
@@ -6,7 +6,7 @@ package parsing
 trait ExpressionExtractors { self: Extractors =>
 
   trait ExpressionExtractor { self0: Extractor =>
-
+    import symbols.given
     import ExprIR._
 
     private type MatchObligation = Option[Match]
@@ -196,7 +196,6 @@ trait ExpressionExtractors { self: Extractors =>
             optTemplatesTypes match {
               case None => extract(toExprObls(args -> templateArgs))
               case Some(templateTypes) => extract(toExprObls(args -> templateArgs), toTypeObls(tpes -> templateTypes))
-              case _ => fail
             }
           }
           case Application(TypeApplication(ExpressionHole(index), templateTypes), templateArgs) => for {
@@ -215,7 +214,6 @@ trait ExpressionExtractors { self: Extractors =>
             optTemplatesTypes match {
               case None => extract(toExprObls(args -> templateArgs))
               case Some(templateTypes) => extract(toExprObls(args -> templateArgs), toTypeObls(tpes -> templateTypes))
-              case _ => fail
             }
           }
           case Application(TypeApplication(ExpressionHole(index), templateTypes), templateArgs) => for {
@@ -239,7 +237,7 @@ trait ExpressionExtractors { self: Extractors =>
         // Instance checking and casting.
 
         case trees.IsConstructor(inner, id) => template match {
-          case IsConstructorOperation(templateInner, name) if id.name == name =>
+          case IsConstructorOperation(templateInner, adtCons) if id.name == adtCons.id.name =>
             extract(toExprObl(inner -> templateInner))
           case _ => fail
         }
@@ -462,31 +460,31 @@ trait ExpressionExtractors { self: Extractors =>
           case _ => fail
         }
 
-        case trees.SetAdd(set, element) => (set.getType(symbols), template) match {
+        case trees.SetAdd(set, element) => (set.getType, template) match {
           case (trees.SetType(tpe), SetAddOperation(templateSet, templateElement, optTemplateType)) =>
             extract(toExprObl(set -> templateSet), toExprObl(element -> templateElement), toOptTypeObl(tpe -> optTemplateType))
           case _ => fail
         }
 
-        case trees.ElementOfSet(element, set) => (set.getType(symbols), template) match {
+        case trees.ElementOfSet(element, set) => (set.getType, template) match {
           case (trees.SetType(tpe), ContainsOperation(templateSet, templateElement, optTemplateType)) =>
             extract(toExprObl(set -> templateSet), toExprObl(element -> templateElement), toOptTypeObl(tpe -> optTemplateType))
           case _ => fail
         }
 
-        case trees.SubsetOf(left, right) => (left.getType(symbols), template) match {
+        case trees.SubsetOf(left, right) => (left.getType, template) match {
           case (trees.SetType(tpe), SubsetOperation(templateLeft, templateRight, optTemplateType)) =>
             extract(toExprObl(left -> templateLeft), toExprObl(right -> templateRight), toOptTypeObl(tpe -> optTemplateType))
           case _ => fail
         }
 
-        case trees.SetIntersection(left, right) => (left.getType(symbols), template) match {
+        case trees.SetIntersection(left, right) => (left.getType, template) match {
           case (trees.SetType(tpe), SetIntersectionOperation(templateLeft, templateRight, optTemplateType)) =>
             extract(toExprObl(left -> templateLeft), toExprObl(right -> templateRight), toOptTypeObl(tpe -> optTemplateType))
           case _ => fail
         }
 
-        case trees.SetDifference(left, right) => (left.getType(symbols), template) match {
+        case trees.SetDifference(left, right) => (left.getType, template) match {
           case (trees.SetType(tpe), SetDifferenceOperation(templateLeft, templateRight, optTemplateType)) =>
             extract(toExprObl(left -> templateLeft), toExprObl(right -> templateRight), toOptTypeObl(tpe -> optTemplateType))
           case _ => fail
@@ -504,7 +502,7 @@ trait ExpressionExtractors { self: Extractors =>
           case _ => fail
         }
 
-        case trees.BagAdd(bag, element) => (bag.getType(symbols), template) match {
+        case trees.BagAdd(bag, element) => (bag.getType, template) match {
           case (trees.BagType(tpe), BagAddOperation(templateBag, templateElement, optTemplateType)) =>
             extract(toExprObl(bag -> templateBag), toExprObl(element -> templateElement), toOptTypeObl(tpe -> optTemplateType))
           case _ => fail

--- a/src/main/scala/inox/parsing/Interpolator.scala
+++ b/src/main/scala/inox/parsing/Interpolator.scala
@@ -13,19 +13,18 @@ trait Interpolator
 
   import trees._
 
-  class Converter(implicit val symbols: trees.Symbols)
+  class Converter(using val symbols: trees.Symbols)
     extends Elaborator
        with Extractor
 
-  implicit class ExpressionInterpolator(sc: StringContext)(implicit symbols: trees.Symbols = trees.NoSymbols) {
-
+  implicit class ExpressionInterpolator(sc: StringContext)(using symbols: trees.Symbols = trees.NoSymbols) {
     private lazy val converter = new Converter()
     private lazy val parser = new DefinitionParser()
 
     object e {
       def apply(args: Any*): Expr = {
         val ire = ir(args : _*)
-        val expr = converter.getExpr(ire, Unknown.fresh(ire.pos))(Store.empty)
+        val expr = converter.getExpr(ire, Unknown.fresh(using ire.pos))(using Store.empty)
         converter.elaborate(expr)
       }
 
@@ -45,7 +44,7 @@ trait Interpolator
 
     def v(args: Any*): ValDef = {
       val (id, ir) = parser.getFromSC(sc, args)(parser.phrase(parser.inoxValDef))
-      val tpe = converter.getType(ir)(Store.empty)
+      val tpe = converter.getType(ir)(using Store.empty)
       trees.ValDef(id, converter.elaborate(tpe))
     }
 
@@ -65,7 +64,7 @@ trait Interpolator
     object t {
       def apply(args: Any*): Type = {
         val ir = parser.getFromSC(sc, args)(parser.phrase(parser.typeExpression))
-        val tpe = converter.getType(ir)(Store.empty)
+        val tpe = converter.getType(ir)(using Store.empty)
         converter.elaborate(tpe)
       }
 
@@ -82,7 +81,7 @@ trait Interpolator
     object td {
       def apply(args: Any*): ADTSort = {
         val ir = parser.getFromSC(sc, args)(parser.phrase(parser.datatype))
-        val srt = converter.getSort(ir)(Store.empty)
+        val srt = converter.getSort(ir)(using Store.empty)
         converter.elaborate(srt)
       }
 
@@ -99,7 +98,7 @@ trait Interpolator
     object fd {
       def apply(args: Any*): FunDef = {
         val ir = parser.getFromSC(sc, args)(parser.phrase(parser.function))
-        val fundef = converter.getFunction(ir)(Store.empty)
+        val fundef = converter.getFunction(ir)(using Store.empty)
         converter.elaborate(fundef)
       }
 

--- a/src/main/scala/inox/parsing/PositionalErrors.scala
+++ b/src/main/scala/inox/parsing/PositionalErrors.scala
@@ -8,7 +8,7 @@ import scala.util.parsing.input._
 
 trait PositionalErrors { self: scala.util.parsing.combinator.Parsers =>
 
-  implicit class PositionalErrorsDecorator[A](parser: Parser[A]) {
+  extension [A](parser: Parser[A]) {
 
     def withErrorMessage(onError: Position => String): Parser[A] = new Parser[A] {
       override def apply(input: Input) = parser(input) match {

--- a/src/main/scala/inox/parsing/StringContextLexer.scala
+++ b/src/main/scala/inox/parsing/StringContextLexer.scala
@@ -9,7 +9,7 @@ import scala.util.parsing.combinator.token._
 import scala.util.parsing.input._
 
 /** Contains methods for lexical parsing of StringContext objects and their arguments. */
-trait StringContextLexer extends { self: Lexical =>
+trait StringContextLexer { self: Lexical =>
 
   /** Converts an argument of the StringContext to a Token. */
   def argToToken(x: Any): Token

--- a/src/main/scala/inox/parsing/StringContextParsers.scala
+++ b/src/main/scala/inox/parsing/StringContextParsers.scala
@@ -13,5 +13,6 @@ trait StringContextParsers { self: TokenParsers { type Tokens <: StringContextLe
     parser(lexical.getReader(sc, args)) match {
       case NoSuccess(msg, _) => throw ParsingException(msg)
       case Success(value, _) => value
+      case otherwise => sys.error(s"Unexpected case: $otherwise")
     }
 }

--- a/src/main/scala/inox/parsing/TypeExtractor.scala
+++ b/src/main/scala/inox/parsing/TypeExtractor.scala
@@ -26,7 +26,7 @@ trait TypeExtractors { self: Extractors =>
         } yield matchingsHead ++ matchingsRest
     }
 
-    def extractSeq(vds: Seq[trees.ValDef], templates: Seq[Expression])(implicit dummy: DummyImplicit): Option[Match] =
+    def extractSeq(vds: Seq[trees.ValDef], templates: Seq[Expression])(using DummyImplicit): Option[Match] =
       (vds, templates) match {
         case (Seq(), Seq()) => Some(empty)
         case (Seq(), _) => None

--- a/src/main/scala/inox/solvers/ADTManagers.scala
+++ b/src/main/scala/inox/solvers/ADTManagers.scala
@@ -9,27 +9,27 @@ trait ADTManagers {
   val program: Program
   val context: Context
 
-  import context._
+  import context.{given, _}
   import program._
   import program.trees._
-  import program.symbols._
+  import program.symbols.{given, _}
 
   protected def unsupported(t: Tree, str: String): Nothing
 
   case class DataType(sym: Identifier, cases: Seq[Constructor]) extends Printable {
-    def asString(implicit opts: PrinterOptions) = {
-      "Datatype: " + sym.asString(opts) + "\n" + cases.map(c => " - " + c.asString(opts)).mkString("\n")
+    def asString(using opts: PrinterOptions) = {
+      "Datatype: " + sym.asString + "\n" + cases.map(c => " - " + c.asString).mkString("\n")
     }
   }
 
   sealed abstract class ConsType extends Tree {
-    override def asString(implicit opts: PrinterOptions) = this match {
+    override def asString(using PrinterOptions) = this match {
       case ADTCons(id, tps) =>
-        id.asString(opts) +
-        (if (tps.nonEmpty) tps.map(_.asString(opts)).mkString("[", ",", "]") else "")
-      case TupleCons(tps) => TupleType(tps).asString(opts)
-      case TypeParameterCons(tp) => tp.asString(opts)
-      case UnitCons => UnitType().asString(opts)
+        id.asString +
+        (if (tps.nonEmpty) tps.map(_.asString).mkString("[", ",", "]") else "")
+      case TupleCons(tps) => TupleType(tps).asString
+      case TypeParameterCons(tp) => tp.asString
+      case UnitCons => UnitType().asString
     }
 
     def getType: Type
@@ -48,10 +48,10 @@ trait ADTManagers {
   }
 
   case class Constructor(sym: Identifier, tpe: ConsType, fields: Seq[(Identifier, Type)]) extends Printable {
-    def asString(implicit opts: PrinterOptions) = {
-      sym.asString(opts) +
-      " [" + tpe.asString(opts) + "] " +
-      fields.map(f => f._1.asString(opts) + ": " + f._2.asString(opts)).mkString("(", ", ", ")")
+    def asString(using PrinterOptions) = {
+      sym.asString +
+      " [" + tpe.asString + "] " +
+      fields.map(f => f._1.asString + ": " + f._2.asString).mkString("(", ", ", ")")
     }
   }
 

--- a/src/main/scala/inox/solvers/Solver.scala
+++ b/src/main/scala/inox/solvers/Solver.scala
@@ -15,7 +15,7 @@ trait AbstractSolver extends Interruptible {
   val program: Program
   val context: Context
 
-  import context._
+  import context.{given, _}
   import program._
   import program.trees._
 
@@ -56,7 +56,8 @@ trait AbstractSolver extends Interruptible {
   def push(): Unit
   def pop(): Unit
 
-  implicit val debugSection: DebugSection = DebugSectionSolver
+  val debugSection: DebugSection = DebugSectionSolver
+  given givenSolverDebugSection: DebugSection = debugSection
 
   private[solvers] def debugS(msg: String) = {
     reporter.debug("["+name+"] "+msg)

--- a/src/main/scala/inox/solvers/SolverResponses.scala
+++ b/src/main/scala/inox/solvers/SolverResponses.scala
@@ -80,13 +80,14 @@ object SolverResponses {
     }
 
     def min(that: Configuration): Configuration = (this, that) match {
-      case (o1, o2) if o1 == o2 => o1
       case (Simple, _) => Simple
       case (_, Simple) => Simple
       case (Model, UnsatAssumptions) => Simple
       case (UnsatAssumptions, Model) => Simple
       case (All, o) => o
       case (o, All) => o
+      case (Model, Model) => Model
+      case (UnsatAssumptions, UnsatAssumptions) => UnsatAssumptions
     }
 
     def cast[M, C](resp: SolverResponse[M,C]): Response[M,C] = ((this, resp) match {

--- a/src/main/scala/inox/solvers/combinators/EncodingSolverFactory.scala
+++ b/src/main/scala/inox/solvers/combinators/EncodingSolverFactory.scala
@@ -14,12 +14,9 @@ object EncodingSolverFactory {
              val program: p.type
              type S <: TimeoutSolver { val program: p.type }
            } = {
+    class Impl(override val program: p.type)
+      extends EncodingSolver(p, enc, sf.getNewSolver()) with TimeoutSolver
 
-    SolverFactory.create(p)("E:" + sf.name, () => new {
-      val program: p.type = p
-    } with EncodingSolver with TimeoutSolver {
-      val encoder: enc.type = enc
-      val underlying = sf.getNewSolver()
-    })
+    SolverFactory.create(p)("E:" + sf.name, () => new Impl(p))
   }
 }

--- a/src/main/scala/inox/solvers/combinators/PortfolioSolver.scala
+++ b/src/main/scala/inox/solvers/combinators/PortfolioSolver.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait PortfolioSolver extends Solver { self =>
-  import context._
+  import context.{given, _}
   import program._
   import program.trees._
 

--- a/src/main/scala/inox/solvers/combinators/SolverPoolFactory.scala
+++ b/src/main/scala/inox/solvers/combinators/SolverPoolFactory.scala
@@ -16,13 +16,12 @@ import scala.collection.mutable.Queue
  * growing/shrinking pool size...
  */
 
-trait SolverPoolFactory extends SolverFactory { self =>
-
-  val factory: SolverFactory
-  val program: factory.program.type = factory.program
+class SolverPoolFactory private(val factory: SolverFactory)
+                               (override val program: factory.program.type, override val name: String)
+  extends SolverFactory { self =>
   type S = factory.S
 
-  val name = "Pool(" + factory.name + ")"
+  def this(factory: SolverFactory) = this(factory)(factory.program, "Pool(" + factory.name + ")")
 
   var poolSize    = 0
   val poolMaxSize = 5
@@ -80,7 +79,8 @@ trait SolverPoolFactory extends SolverFactory { self =>
 object SolverPoolFactory {
   def apply(sf: SolverFactory): SolverPoolFactory {
     val factory: sf.type
-  } = new {
-    val factory: sf.type = sf
-  } with SolverPoolFactory
+  } = {
+    class Impl(override val factory: sf.type) extends SolverPoolFactory(factory)
+    new Impl(sf)
+  }
 }

--- a/src/main/scala/inox/solvers/package.scala
+++ b/src/main/scala/inox/solvers/package.scala
@@ -53,12 +53,12 @@ package object solvers {
         type S = self.factory.S { val program: self.factory.program.type }
       }]
 
-      new TimeoutSolverFactory {
-        val program: self.factory.program.type = innerFactory.program
-        type S = self.factory.S { val program: self.factory.program.type }
-        val to = timeout
-        val factory = innerFactory
-      }
+      // The casts are sadly needed; the trick with local class overriding `program` does not seem to work due to needing to override other things
+      new TimeoutSolverFactory(innerFactory.program, timeout, new { type S = innerFactory.S }, innerFactory.asInstanceOf)
+        .asInstanceOf[TimeoutSolverFactory {
+          val program: self.factory.program.type
+          type S = self.factory.S { val program: self.factory.program.type }
+        }]
     }
 
     def withTimeout(du: Duration): TimeoutSolverFactory {

--- a/src/main/scala/inox/solvers/smtlib/CVC4Solver.scala
+++ b/src/main/scala/inox/solvers/smtlib/CVC4Solver.scala
@@ -14,7 +14,7 @@ object optCVC4Options extends SetOptionDef[String] {
 }
 
 trait CVC4Solver extends SMTLIBSolver with CVC4Target {
-  import context._
+  import context.{given, _}
   import program.trees._
   import SolverResponses._
 

--- a/src/main/scala/inox/solvers/smtlib/SMTLIBDebugger.scala
+++ b/src/main/scala/inox/solvers/smtlib/SMTLIBDebugger.scala
@@ -10,12 +10,13 @@ import _root_.smtlib.trees.Terms._
 case object DebugSectionSMT extends DebugSection("smt")
 
 trait SMTLIBDebugger extends SMTLIBTarget {
-  import context._
+  import context.{given, _}
   import program._
 
   protected def interpreterOpts: Seq[String]
 
-  implicit val debugSection: DebugSection
+  val debugSection: DebugSection
+  given givenSmtlibDebugSection: DebugSection = debugSection
 
   override def free(): Unit = {
     super.free()
@@ -24,7 +25,7 @@ trait SMTLIBDebugger extends SMTLIBTarget {
 
   /* Printing VCs */
   protected lazy val debugOut: Option[java.io.FileWriter] = {
-    implicit val debugSection = DebugSectionSMT
+    given DebugSectionSMT.type = DebugSectionSMT
     if (reporter.isDebugEnabled) {
       val file = options.findOptionOrDefault(Main.optFiles).headOption.map(_.getName).getOrElse("NA")
       val n = DebugFileNumbers.next(targetName + file)

--- a/src/main/scala/inox/solvers/smtlib/Z3Solver.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Solver.scala
@@ -12,7 +12,7 @@ trait Z3Solver extends SMTLIBSolver with Z3Target { self =>
   import SolverResponses._
 
   protected lazy val evaluator: evaluators.DeterministicEvaluator { val program: self.program.type } =
-    semantics.getEvaluator(context.withOpts(evaluators.optIgnoreContracts(true)))
+    semantics.getEvaluator(using context.withOpts(evaluators.optIgnoreContracts(true)))
 
   // XXX @nv: Sometimes Z3 doesn't return fully evaluated models so we make sure to
   //          bring them into some normal form after extraction
@@ -45,7 +45,7 @@ trait Z3Solver extends SMTLIBSolver with Z3Target { self =>
       case t => unsupported(t, "Assumptions must be either variables or their negation")
     }
 
-    val cmd = SList(SSymbol("check-sat") +: assumptions.toSeq.map(as => toSMT(as)(Map.empty)) : _*)
+    val cmd = SList(SSymbol("check-sat") +: assumptions.toSeq.map(as => toSMT(as)(using Map.empty)) : _*)
     val res = emit(cmd) match {
       case SSymbol("sat") => CheckSatStatus(SatStatus)
       case SSymbol("unsat") => CheckSatStatus(UnsatStatus)

--- a/src/main/scala/inox/solvers/smtlib/optimization/Z3Optimizer.scala
+++ b/src/main/scala/inox/solvers/smtlib/optimization/Z3Optimizer.scala
@@ -10,19 +10,19 @@ import Commands._
 trait Z3Optimizer extends Z3Solver with AbstractOptimizer {
   import program._
   import program.trees._
-  import program.symbols._
+  import program.symbols.{given, _}
 
   def assertCnstr(expr: Expr, weight: Int): Unit = {
     exprOps.variablesOf(expr).foreach(declareVariable)
 
-    val term = toSMT(expr)(Map())
+    val term = toSMT(expr)(using Map())
     emit(AssertSoft(term, Some(weight), None))
   }
 
   def assertCnstr(expr: Expr, weight: Int, group: String): Unit = {
     exprOps.variablesOf(expr).foreach(declareVariable)
 
-    val term = toSMT(expr)(Map())
+    val term = toSMT(expr)(using Map())
     emit(AssertSoft(term, Some(weight), Some(group)))
   }
 }

--- a/src/main/scala/inox/solvers/theories/ASCIIStringEncoder.scala
+++ b/src/main/scala/inox/solvers/theories/ASCIIStringEncoder.scala
@@ -7,7 +7,21 @@ package theories
 import utils._
 import utils.StringUtils._
 
-trait ASCIIStringEncoder extends SimpleEncoder {
+class ASCIIStringEncoder private(override val sourceProgram: Program)
+                                (theory: ASCIIStringTheory[sourceProgram.trees.type])
+  extends SimpleEncoder(
+    sourceProgram,
+    new ASCIIStringEnc[sourceProgram.trees.type](sourceProgram.trees, theory).asInstanceOf,
+    new ASCIIStringDec[sourceProgram.trees.type](sourceProgram.trees, theory).asInstanceOf,
+    theory.extraFunctions,
+    theory.extraSorts)
+
+object ASCIIStringEncoder {
+  def apply(p: Program): ASCIIStringEncoder { val sourceProgram: p.type } =
+    new ASCIIStringEncoder(p)(new ASCIIStringTheory(p.trees)).asInstanceOf
+}
+
+private class ASCIIStringTheory[Trees <: ast.Trees](val trees: Trees) {
   import trees._
   import trees.dsl._
 
@@ -24,111 +38,114 @@ trait ASCIIStringEncoder extends SimpleEncoder {
 
   val invariant = mkFunDef(inv)()(_ => (
     Seq("s" :: String), BooleanType(), { case Seq(s) =>
-      StringLength(s.getField(value)) % E(BigInt(2)) === E(BigInt(0))
-    }))
+    StringLength(s.getField(value)) % E(BigInt(2)) === E(BigInt(0))
+  }))
 
-  override protected val extraFunctions = Seq(invariant)
-  override protected val extraSorts = Seq(stringSort)
+  val extraFunctions = Seq(invariant)
+  val extraSorts = Seq(stringSort)
+}
 
-  private object FirstBytes {
-    def unapply(s: String): Option[(Byte, Byte, String)] = s match {
-      case JavaEncoded(b1, JavaEncoded(b2, s2)) => Some((b1, b2, s2))
-      case _ if s.isEmpty => None
-      case _ => s.charAt(0).toString.getBytes("UTF-8").toSeq match {
-        case Seq(_) if s.length == 1 => None
-        case Seq(b1) => s.charAt(1).toString.getBytes("UTF-8").toSeq match {
-          case Seq(b2) => Some((b1, b2, s.drop(2)))
-          case _ => None
-        }
-        case Seq(b1, b2) =>
-          val i1 = new java.lang.String(Seq(b1, b2).toArray, "UTF-8").charAt(0).toInt
-          if ((i1 & 0xFFFFFFE0) == 0xC0) {
-            if (s.length == 1) None else s.charAt(1).toString.getBytes("UTF-8").toSeq match {
-              case Seq(b3, b4) =>
-                val i2 = new java.lang.String(Seq(b3, b4).toArray, "UTF-8").charAt(0).toInt
-                if ((i2 & 0xFFFFFFC0) == 0x80) Some((i1.toByte, i2.toByte, s.drop(2)))
-                else None
-              case _ => None
-            }
-          } else {
-            Some((b1, b2, s.tail))
-          }
-      }
-    }
-  }
+private class ASCIIStringEnc[Trees <: ast.Trees](val trees: Trees, val theory: ASCIIStringTheory[trees.type]) extends trees.ConcreteSelfTreeTransformer {
+  import trees._
+  import trees.dsl._
+  import theory._
 
   private val TWO = IntegerLiteral(2)
 
-  protected object encoder extends SelfTreeTransformer {
-    override def transform(e: Expr): Expr = e match {
-      case StringLiteral(v) =>
-        stringCons(StringLiteral(v.flatMap(c => c.toString.getBytes("UTF-8").toSeq match {
-          case Seq(b) if 32 <= b && b <= 127 => b.toChar.toString + b.toChar.toString
-          case Seq(b) => encodeByte(b) + encodeByte(b)
-          case Seq(b1, b2) => encodeByte(b1) + encodeByte(b2)
-        })))
-      case StringLength(a) => Division(StringLength(transform(a).getField(value)), TWO)
-      case StringConcat(a, b) => stringCons(StringConcat(transform(a).getField(value), transform(b).getField(value)))
-      case SubString(a, start, end) => stringCons(SubString(transform(a).getField(value), transform(start) * TWO, transform(end) * TWO))
-      case _ => super.transform(e)
-    }
-
-    override def transform(tpe: Type): Type = tpe match {
-      case StringType() => String
-      case _ => super.transform(tpe)
-    }
+  override def transform(e: Expr): Expr = e match {
+    case StringLiteral(v) =>
+      stringCons(StringLiteral(v.flatMap(c => c.toString.getBytes("UTF-8").toSeq match {
+        case Seq(b) if 32 <= b && b <= 127 => b.toChar.toString + b.toChar.toString
+        case Seq(b) => encodeByte(b) + encodeByte(b)
+        case Seq(b1, b2) => encodeByte(b1) + encodeByte(b2)
+      })))
+    case StringLength(a) => Division(StringLength(transform(a).getField(value)), TWO)
+    case StringConcat(a, b) => stringCons(StringConcat(transform(a).getField(value), transform(b).getField(value)))
+    case SubString(a, start, end) => stringCons(SubString(transform(a).getField(value), transform(start) * TWO, transform(end) * TWO))
+    case _ => super.transform(e)
   }
 
-  protected object decoder extends SelfTreeTransformer {
-
-    override def transform(e: Expr): Expr = e match {
-      case ADT(StringConsID, Seq(), Seq(StringLiteral(s))) =>
-        def unescape(s: String): String = if (s.isEmpty) s else (s match {
-          case FirstBytes(b1, b2, s2) =>
-            val h: String = if (0 <= b1 && b1 <= 127 && b1 == b2) {
-              b1.toChar.toString
-            } else if (0 <= b1 && b1 <= 127 && 0 <= b2 && b2 <= 127) {
-              new java.lang.String(Seq(
-                (0x00 | (b1 >> 1)).toByte,
-                (((b1 & 1) << 7) | b2).toByte
-              ).toArray, "UTF-8")
-            } else if ((b1 & 0xE0) == 0xC0) {
-              new java.lang.String(Seq(b1, b2).toArray, "UTF-8")
-            } else {
-              // hopefully these are rare!
-              throw TheoryException(s"Can't decode character ${encodeByte(b1)}${encodeByte(b2)}")
-            }
-            h + unescape(s2)
-
-          case _ =>
-            throw TheoryException(s"Can't decode string $s")
-        })
-
-        StringLiteral(unescape(s))
-
-      case ADTSelector(a, `value`) => transform(a)
-
-      case Division(StringLength(a), TWO) =>
-        StringLength(transform(a))
-
-      case ADT(StringConsID, Seq(), Seq(StringConcat(a, b))) =>
-        StringConcat(transform(a), transform(b))
-
-      case ADT(StringConsID, Seq(), Seq(SubString(a, Times(start, TWO), Times(end, TWO)))) =>
-        SubString(transform(a), transform(start), transform(end))
-
-      case _ => super.transform(e)
-    }
-
-    override def transform(tpe: Type): Type = tpe match {
-      case String => StringType()
-      case _ => super.transform(tpe)
-    }
+  override def transform(tpe: Type): Type = tpe match {
+    case StringType() => String
+    case _ => super.transform(tpe)
   }
 }
 
-object ASCIIStringEncoder {
-  def apply(p: Program): ASCIIStringEncoder { val sourceProgram: p.type } = new {
-    val sourceProgram: p.type = p
-  } with ASCIIStringEncoder
+private class ASCIIStringDec[Trees <: ast.Trees](val trees: Trees, val theory: ASCIIStringTheory[trees.type]) extends trees.ConcreteSelfTreeTransformer {
+  import trees._
+  import trees.dsl._
+  import theory._
+
+  private val TWO = IntegerLiteral(2)
+
+  override def transform(e: Expr): Expr = e match {
+    case ADT(StringConsID, Seq(), Seq(StringLiteral(s))) =>
+      def unescape(s: String): String = if (s.isEmpty) s else (s match {
+        case FirstBytes(b1, b2, s2) =>
+          val h: String = if (0 <= b1 && b1 <= 127 && b1 == b2) {
+            b1.toChar.toString
+          } else if (0 <= b1 && b1 <= 127 && 0 <= b2 && b2 <= 127) {
+            new java.lang.String(Seq(
+              (0x00 | (b1 >> 1)).toByte,
+              (((b1 & 1) << 7) | b2).toByte
+            ).toArray, "UTF-8")
+          } else if ((b1 & 0xE0) == 0xC0) {
+            new java.lang.String(Seq(b1, b2).toArray, "UTF-8")
+          } else {
+            // hopefully these are rare!
+            throw TheoryException(s"Can't decode character ${encodeByte(b1)}${encodeByte(b2)}")
+          }
+          h + unescape(s2)
+
+        case _ =>
+          throw TheoryException(s"Can't decode string $s")
+      })
+
+      StringLiteral(unescape(s))
+
+    case ADTSelector(a, `value`) => transform(a)
+
+    case Division(StringLength(a), TWO) =>
+      StringLength(transform(a))
+
+    case ADT(StringConsID, Seq(), Seq(StringConcat(a, b))) =>
+      StringConcat(transform(a), transform(b))
+
+    case ADT(StringConsID, Seq(), Seq(SubString(a, Times(start, TWO), Times(end, TWO)))) =>
+      SubString(transform(a), transform(start), transform(end))
+
+    case _ => super.transform(e)
+  }
+
+  override def transform(tpe: Type): Type = tpe match {
+    case String => StringType()
+    case _ => super.transform(tpe)
+  }
+}
+
+private object FirstBytes {
+  def unapply(s: String): Option[(Byte, Byte, String)] = s match {
+    case JavaEncoded(b1, JavaEncoded(b2, s2)) => Some((b1, b2, s2))
+    case _ if s.isEmpty => None
+    case _ => s.charAt(0).toString.getBytes("UTF-8").toSeq match {
+      case Seq(_) if s.length == 1 => None
+      case Seq(b1) => s.charAt(1).toString.getBytes("UTF-8").toSeq match {
+        case Seq(b2) => Some((b1, b2, s.drop(2)))
+        case _ => None
+      }
+      case Seq(b1, b2) =>
+        val i1 = new java.lang.String(Seq(b1, b2).toArray, "UTF-8").charAt(0).toInt
+        if ((i1 & 0xFFFFFFE0) == 0xC0) {
+          if (s.length == 1) None else s.charAt(1).toString.getBytes("UTF-8").toSeq match {
+            case Seq(b3, b4) =>
+              val i2 = new java.lang.String(Seq(b3, b4).toArray, "UTF-8").charAt(0).toInt
+              if ((i2 & 0xFFFFFFC0) == 0x80) Some((i1.toByte, i2.toByte, s.drop(2)))
+              else None
+            case _ => None
+          }
+        } else {
+          Some((b1, b2, s.tail))
+        }
+    }
+  }
 }

--- a/src/main/scala/inox/solvers/theories/BagEncoder.scala
+++ b/src/main/scala/inox/solvers/theories/BagEncoder.scala
@@ -6,13 +6,23 @@ package theories
 
 import evaluators._
 
-trait BagEncoder extends SimpleEncoder {
+class BagEncoder private
+  (val enc: transformers.ProgramTransformer)
+  (override val sourceProgram: enc.targetProgram.type)
+  (evaluator: DeterministicEvaluator {
+    val program: sourceProgram.type
+  })
+  (theory: BagTheory[sourceProgram.trees.type])
+  extends SimpleEncoder(
+    sourceProgram,
+    new BagEnc[sourceProgram.type](sourceProgram)(theory)(evaluator).asInstanceOf,
+    new BagDec[sourceProgram.type](sourceProgram)(theory)(evaluator).asInstanceOf,
+    theory.extraFunctions,
+    theory.extraSorts)
+
+private class BagTheory[Trees <: ast.Trees](val trees: Trees) {
   import trees._
   import trees.dsl._
-
-  val evaluator: DeterministicEvaluator {
-    val program: sourceProgram.type
-  }
 
   val BagID  = FreshIdentifier("Bag")
   val SumID  = FreshIdentifier("Sum")
@@ -32,17 +42,17 @@ trait BagEncoder extends SimpleEncoder {
   val GetID = FreshIdentifier("get")
   val Get = mkFunDef(GetID)("T") { case Seq(aT) => (
     Seq("bag" :: Bag(aT), "x" :: aT), IntegerType(), {
-      case Seq(bag, x) => if_ (bag is SumID) {
-        E(GetID)(aT)(bag.getField(left), x) +
-          E(GetID)(aT)(bag.getField(right), x)
+    case Seq(bag, x) => if_ (bag is SumID) {
+      E(GetID)(aT)(bag.getField(left), x) +
+        E(GetID)(aT)(bag.getField(right), x)
+    } else_ {
+      if_ (bag.is(ElemID) && bag.getField(key) === x) {
+        bag.getField(value)
       } else_ {
-        if_ (bag.is(ElemID) && bag.getField(key) === x) {
-          bag.getField(value)
-        } else_ {
-          E(BigInt(0))
-        }
+        E(BigInt(0))
       }
-    })
+    }
+  })
   }
 
   val AddID = FreshIdentifier("add")
@@ -58,21 +68,21 @@ trait BagEncoder extends SimpleEncoder {
   val diff = FreshIdentifier("diffImpl")
   val DifferenceImpl = mkFunDef(diff)("T") { case Seq(aT) => (
     Seq("keys" :: Bag(aT), "b1" :: Bag(aT), "b2" :: Bag(aT)), Bag(aT), {
-      case Seq(keys, b1, b2) => if_ (keys is SumID) {
-        Sum(aT)(E(diff)(aT)(keys.getField(left), b1, b2),
-          E(diff)(aT)(keys.getField(right), b1, b2))
-      } else_ {
-        if_ (keys is ElemID) {
-          let("f" :: aT, keys.getField(key)) { f =>
-            let("d" :: IntegerType(), Get(aT)(b1, f) - Get(aT)(b2, f)) { d =>
-              if_ (d < E(BigInt(0))) { Leaf(aT)() } else_ { Elem(aT)(f, d) }
-            }
+    case Seq(keys, b1, b2) => if_ (keys is SumID) {
+      Sum(aT)(E(diff)(aT)(keys.getField(left), b1, b2),
+        E(diff)(aT)(keys.getField(right), b1, b2))
+    } else_ {
+      if_ (keys is ElemID) {
+        let("f" :: aT, keys.getField(key)) { f =>
+          let("d" :: IntegerType(), Get(aT)(b1, f) - Get(aT)(b2, f)) { d =>
+            if_ (d < E(BigInt(0))) { Leaf(aT)() } else_ { Elem(aT)(f, d) }
           }
-        } else_ {
-          Leaf(aT)()
         }
+      } else_ {
+        Leaf(aT)()
       }
-    })
+    }
+  })
   }
 
   val DifferenceID = FreshIdentifier("difference")
@@ -83,23 +93,23 @@ trait BagEncoder extends SimpleEncoder {
   val inter = FreshIdentifier("interImpl")
   val IntersectImpl = mkFunDef(inter)("T") { case Seq(aT) => (
     Seq("keys" :: Bag(aT), "b1" :: Bag(aT), "b2" :: Bag(aT)), Bag(aT), {
-      case Seq(keys, b1, b2) => if_ (keys is SumID) {
-        Sum(aT)(E(inter)(aT)(keys.getField(left), b1, b2),
-          E(inter)(aT)(keys.getField(right), b1, b2))
-      } else_ {
-        if_ (keys is ElemID) {
-          let("f" :: aT, keys.getField(key)) { f =>
-            let("v1" :: IntegerType(), Get(aT)(b1, f)) { v1 =>
-              let("v2" :: IntegerType(), Get(aT)(b2, f)) { v2 =>
-                Elem(aT)(f, if_ (v1 <= v2) { v1 } else_ { v2 })
-              }
+    case Seq(keys, b1, b2) => if_ (keys is SumID) {
+      Sum(aT)(E(inter)(aT)(keys.getField(left), b1, b2),
+        E(inter)(aT)(keys.getField(right), b1, b2))
+    } else_ {
+      if_ (keys is ElemID) {
+        let("f" :: aT, keys.getField(key)) { f =>
+          let("v1" :: IntegerType(), Get(aT)(b1, f)) { v1 =>
+            let("v2" :: IntegerType(), Get(aT)(b2, f)) { v2 =>
+              Elem(aT)(f, if_ (v1 <= v2) { v1 } else_ { v2 })
             }
           }
-        } else_ {
-          Leaf(aT)()
         }
+      } else_ {
+        Leaf(aT)()
       }
-    })
+    }
+  })
   }
 
   val IntersectID = FreshIdentifier("intersect")
@@ -110,19 +120,19 @@ trait BagEncoder extends SimpleEncoder {
   val EqualsID = FreshIdentifier("equals")
   val BagEquals = mkFunDef(EqualsID)("T") { case Seq(aT) => (
     Seq("b1" :: Bag(aT), "b2" :: Bag(aT)), BooleanType(), {
-      case Seq(b1, b2) => forall("x" :: aT)(x => Get(aT)(b1, x) === Get(aT)(b2, x))
-    })
+    case Seq(b1, b2) => forall("x" :: aT)(x => Get(aT)(b1, x) === Get(aT)(b2, x))
+  })
   }
 
   val InvID = FreshIdentifier("inv")
   val BagInvariant = mkFunDef(InvID)("T") { case Seq(aT) => (
     Seq("bag" :: Bag(aT)), BooleanType(), {
-      case Seq(bag) => if_ (bag is ElemID) {
-        bag.getField(value) >= E(BigInt(0))
-      } else_ {
-        E(true)
-      }
-    })
+    case Seq(bag) => if_ (bag is ElemID) {
+      bag.getField(value) >= E(BigInt(0))
+    } else_ {
+      E(true)
+    }
+  })
   }
 
   val bagSort = mkSort(BagID, HasADTEquality(EqualsID), HasADTInvariant(InvID))("T") {
@@ -133,119 +143,134 @@ trait BagEncoder extends SimpleEncoder {
     )
   }
 
-  override val extraFunctions =
+  val extraFunctions =
     Seq(Get, Add, Union, DifferenceImpl, Difference, IntersectImpl, Intersect, BagEquals, BagInvariant)
 
-  override val extraSorts = Seq(bagSort)
+  val extraSorts = Seq(bagSort)
+}
 
-  protected object encoder extends SelfTreeTransformer {
-    import sourceProgram._
-    import evaluator.context._
+private class BagEnc[Prog <: Program]
+  (val sourceProgram: Prog)
+  (val theory: BagTheory[sourceProgram.trees.type])
+  (val evaluator: DeterministicEvaluator {
+   val program: sourceProgram.type
+  }) extends theory.trees.ConcreteSelfTreeTransformer {
+  import theory._
+  import theory.trees._
+  import theory.trees.dsl._
+  import sourceProgram._
+  import sourceProgram.symbols.{given, _}
+  import evaluator.context._
 
-    override def transform(e: Expr): Expr = e match {
-      case FiniteBag(elems, tpe) =>
-        val newTpe = transform(tpe)
-        val newElems = elems.map(p => transform(p._1) -> transform(p._2))
-        newElems.foldRight((Leaf(newTpe)(): Expr, Seq[Expr]())) {
-          case ((key, value), (acc, elems)) => (IfExpr(
-            orJoin(elems.map(e => Equals(e, key))),
-            acc,
-            Sum(newTpe)(acc, Elem(newTpe)(key, value))
-          ), key +: elems)
-        }._1
+  override def transform(e: Expr): Expr = e match {
+    case FiniteBag(elems, tpe) =>
+      val newTpe = transform(tpe)
+      val newElems = elems.map(p => transform(p._1) -> transform(p._2))
+      newElems.foldRight((Leaf(newTpe)(): Expr, Seq[Expr]())) {
+        case ((key, value), (acc, elems)) => (IfExpr(
+          orJoin(elems.map(e => Equals(e, key))),
+          acc,
+          Sum(newTpe)(acc, Elem(newTpe)(key, value))
+        ), key +: elems)
+      }._1
 
-      case BagAdd(bag, elem) =>
-        val BagType(base) = bag.getType
-        Add(transform(base))(transform(bag), transform(elem)).copiedFrom(e)
+    case BagAdd(bag, elem) =>
+      val BagType(base) = bag.getType
+      Add(transform(base))(transform(bag), transform(elem)).copiedFrom(e)
 
-      case MultiplicityInBag(elem, bag) =>
-        val BagType(base) = bag.getType
-        Get(transform(base))(transform(bag), transform(elem)).copiedFrom(e)
+    case MultiplicityInBag(elem, bag) =>
+      val BagType(base) = bag.getType
+      Get(transform(base))(transform(bag), transform(elem)).copiedFrom(e)
 
-      case BagIntersection(b1, b2) =>
-        val BagType(base) = b1.getType
-        Intersect(transform(base))(transform(b1), transform(b2)).copiedFrom(e)
+    case BagIntersection(b1, b2) =>
+      val BagType(base) = b1.getType
+      Intersect(transform(base))(transform(b1), transform(b2)).copiedFrom(e)
 
-      case BagUnion(b1, b2) =>
-        val BagType(base) = b1.getType
-        Union(transform(base))(transform(b1), transform(b2)).copiedFrom(e)
+    case BagUnion(b1, b2) =>
+      val BagType(base) = b1.getType
+      Union(transform(base))(transform(b1), transform(b2)).copiedFrom(e)
 
-      case BagDifference(b1, b2) =>
-        val BagType(base) = b1.getType
-        Difference(transform(base))(transform(b1), transform(b2)).copiedFrom(e)
+    case BagDifference(b1, b2) =>
+      val BagType(base) = b1.getType
+      Difference(transform(base))(transform(b1), transform(b2)).copiedFrom(e)
 
-      case _ => super.transform(e)
-    }
-
-    override def transform(tpe: Type): Type = tpe match {
-      case BagType(base) => Bag(transform(base)).copiedFrom(tpe)
-      case _ => super.transform(tpe)
-    }
+    case _ => super.transform(e)
   }
 
-  protected object decoder extends SelfTreeTransformer {
-    import targetProgram._
-    import evaluator.context._
+  override def transform(tpe: Type): Type = tpe match {
+    case BagType(base) => Bag(transform(base)).copiedFrom(tpe)
+    case _ => super.transform(tpe)
+  }
+}
 
-    override def transform(e: Expr): Expr = e match {
-      case ADT(SumID, Seq(tpe), Seq(e1, e2)) =>
-        val fb1 @ FiniteBag(els1, _) = transform(e1)
-        val fb2 @ FiniteBag(els2, _) = transform(e2)
+private class BagDec[Prog <: Program]
+  (val sourceProgram: Prog)
+  (val theory: BagTheory[sourceProgram.trees.type])
+  (val evaluator: DeterministicEvaluator {
+   val program: sourceProgram.type
+  }) extends theory.trees.ConcreteSelfTreeTransformer {
+  import theory._
+  import theory.trees._
+  import theory.trees.dsl._
+  import evaluator.context.{given, _}
 
-        if (exprOps.variablesOf(fb1).isEmpty && exprOps.variablesOf(fb2).isEmpty) {
-          def groundMap(els: Seq[(Expr, Expr)]): Map[Expr, Expr] = els.map { case (key, value) => (
-            evaluator.eval(key).result.getOrElse(throw new UnsupportedTree(e, "Failed to evaluate bag contents")),
-            evaluator.eval(value).result.getOrElse(throw new UnsupportedTree(e, "Failed to evaluate bag contents"))
-          )}.toMap
+  override def transform(e: Expr): Expr = e match {
+    case ADT(SumID, Seq(tpe), Seq(e1, e2)) =>
+      val fb1 @ FiniteBag(els1, _) = transform(e1)
+      val fb2 @ FiniteBag(els2, _) = transform(e2)
 
-          val map1 = groundMap(els1)
-          val map2 = groundMap(els2)
+      if (exprOps.variablesOf(fb1).isEmpty && exprOps.variablesOf(fb2).isEmpty) {
+        def groundMap(els: Seq[(Expr, Expr)]): Map[Expr, Expr] = els.map { case (key, value) => (
+          evaluator.eval(key).result.getOrElse(throw new UnsupportedTree(e, "Failed to evaluate bag contents")),
+          evaluator.eval(value).result.getOrElse(throw new UnsupportedTree(e, "Failed to evaluate bag contents"))
+        )}.toMap
 
-          FiniteBag((map1.keySet ++ map2.keySet).map { key =>
-            val IntegerLiteral(i1) = map1.getOrElse(key, IntegerLiteral(0))
-            val IntegerLiteral(i2) = map2.getOrElse(key, IntegerLiteral(0))
-            key -> IntegerLiteral(i1 + i2)
-          }.toSeq, transform(tpe)).copiedFrom(e)
-        } else {
-          FiniteBag(els1 ++ els2, transform(tpe)).copiedFrom(e)
-        }
+        val map1 = groundMap(els1)
+        val map2 = groundMap(els2)
 
-      case ADT(ElemID, Seq(tpe), Seq(key, value)) =>
-        FiniteBag(Seq(transform(key) -> transform(value)), transform(tpe)).copiedFrom(e)
+        FiniteBag((map1.keySet ++ map2.keySet).map { key =>
+          val IntegerLiteral(i1) = map1.getOrElse(key, IntegerLiteral(0))
+          val IntegerLiteral(i2) = map2.getOrElse(key, IntegerLiteral(0))
+          key -> IntegerLiteral(i1 + i2)
+        }.toSeq, transform(tpe)).copiedFrom(e)
+      } else {
+        FiniteBag(els1 ++ els2, transform(tpe)).copiedFrom(e)
+      }
 
-      case ADT(LeafID, Seq(tpe), Seq()) =>
-        FiniteBag(Seq.empty, transform(tpe)).copiedFrom(e)
+    case ADT(ElemID, Seq(tpe), Seq(key, value)) =>
+      FiniteBag(Seq(transform(key) -> transform(value)), transform(tpe)).copiedFrom(e)
 
-      case FunctionInvocation(AddID, _, Seq(bag, elem)) =>
-        BagAdd(transform(bag), transform(elem)).copiedFrom(e)
+    case ADT(LeafID, Seq(tpe), Seq()) =>
+      FiniteBag(Seq.empty, transform(tpe)).copiedFrom(e)
 
-      case FunctionInvocation(GetID, _, Seq(bag, elem)) =>
-        MultiplicityInBag(transform(elem), transform(bag)).copiedFrom(e)
+    case FunctionInvocation(AddID, _, Seq(bag, elem)) =>
+      BagAdd(transform(bag), transform(elem)).copiedFrom(e)
 
-      case FunctionInvocation(IntersectID, _, Seq(b1, b2)) =>
-        BagIntersection(transform(b1), transform(b2)).copiedFrom(e)
+    case FunctionInvocation(GetID, _, Seq(bag, elem)) =>
+      MultiplicityInBag(transform(elem), transform(bag)).copiedFrom(e)
 
-      case FunctionInvocation(UnionID, _, Seq(b1, b2)) =>
-        BagUnion(transform(b1), transform(b2)).copiedFrom(e)
+    case FunctionInvocation(IntersectID, _, Seq(b1, b2)) =>
+      BagIntersection(transform(b1), transform(b2)).copiedFrom(e)
 
-      case FunctionInvocation(DifferenceID, _, Seq(b1, b2)) =>
-        BagDifference(transform(b1), transform(b2)).copiedFrom(e)
+    case FunctionInvocation(UnionID, _, Seq(b1, b2)) =>
+      BagUnion(transform(b1), transform(b2)).copiedFrom(e)
 
-      case _ => super.transform(e)
-    }
+    case FunctionInvocation(DifferenceID, _, Seq(b1, b2)) =>
+      BagDifference(transform(b1), transform(b2)).copiedFrom(e)
 
-    override def transform(tpe: Type): Type = tpe match {
-      case ADTType(BagID | SumID | ElemID | LeafID, Seq(base)) => BagType(transform(base)).copiedFrom(tpe)
-      case _ => super.transform(tpe)
-    }
+    case _ => super.transform(e)
+  }
+
+  override def transform(tpe: Type): Type = tpe match {
+    case ADTType(BagID | SumID | ElemID | LeafID, Seq(base)) => BagType(transform(base)).copiedFrom(tpe)
+    case _ => super.transform(tpe)
   }
 }
 
 object BagEncoder {
-  def apply(enc: transformers.ProgramTransformer)
-           (ev: DeterministicEvaluator { val program: enc.sourceProgram.type }):
-           BagEncoder { val sourceProgram: enc.targetProgram.type } = new {
-    val sourceProgram: enc.targetProgram.type = enc.targetProgram
-    val evaluator = ReverseEvaluator(enc)(ev)
-  } with BagEncoder
+  def apply(encc: transformers.ProgramTransformer)
+           (ev: DeterministicEvaluator { val program: encc.sourceProgram.type }):
+           BagEncoder { val sourceProgram: encc.targetProgram.type } =
+    new BagEncoder(encc)(encc.targetProgram)(ReverseEvaluator(encc)(ev))(new BagTheory[encc.targetProgram.trees.type](encc.targetProgram.trees))
+      .asInstanceOf
 }

--- a/src/main/scala/inox/solvers/theories/RealEncoder.scala
+++ b/src/main/scala/inox/solvers/theories/RealEncoder.scala
@@ -4,105 +4,127 @@ package inox
 package solvers
 package theories
 
-trait RealEncoder extends SimpleEncoder {
+class RealEncoder private(override val sourceProgram: Program)
+                         (theory: RealTheory[sourceProgram.trees.type])
+  extends SimpleEncoder(
+    sourceProgram,
+    new RealEnc[sourceProgram.type](sourceProgram)(theory).asInstanceOf,
+    new RealDec[sourceProgram.type](sourceProgram)(theory).asInstanceOf,
+    theory.extraFunctions,
+    theory.extraSorts
+  )
+
+private class RealTheory[Trees <: ast.Trees](val trees: Trees) {
   import trees._
   import trees.dsl._
 
-  private val num = FreshIdentifier("num")
-  private val denom = FreshIdentifier("denom")
-  private val fractionID = FreshIdentifier("fraction")
+  val num = FreshIdentifier("num")
+  val denom = FreshIdentifier("denom")
+  val fractionID = FreshIdentifier("fraction")
 
-  private val fraction_inv = mkFunDef(FreshIdentifier("fraction_inv"))()(_ => (
+  val fraction_inv = mkFunDef(FreshIdentifier("fraction_inv"))()(_ => (
     Seq("x" :: T(fractionID)()), BooleanType(), { case Seq(x) =>
-      !(x.getField(denom) === E(BigInt(0)))
-    }))
+    !(x.getField(denom) === E(BigInt(0)))
+  }))
 
-  private val fraction_eq = mkFunDef(FreshIdentifier("fraction_eq"))()(_ => (
+  val fraction_eq = mkFunDef(FreshIdentifier("fraction_eq"))()(_ => (
     Seq("i1" :: T(fractionID)(), "i2" :: T(fractionID)()), BooleanType(), { case Seq(i1, i2) =>
-      (i1.getField(num) * i2.getField(denom)) === (i1.getField(denom) * i2.getField(num))
-    }))
+    (i1.getField(num) * i2.getField(denom)) === (i1.getField(denom) * i2.getField(num))
+  }))
 
-  private val fraction = mkSort(fractionID)()(_ => Seq(
+  val fraction = mkSort(fractionID)()(_ => Seq(
     (fractionID.freshen, Seq(ValDef(num, IntegerType()), ValDef(denom, IntegerType())))
   ))
 
-  private val fractionCons = fraction.constructors.head
+  val fractionCons = fraction.constructors.head
 
-  override val extraFunctions = Seq(fraction_inv, fraction_eq)
-  override val extraSorts = Seq(fraction)
+  val extraFunctions = Seq(fraction_inv, fraction_eq)
+  val extraSorts = Seq(fraction)
+}
 
-  protected object encoder extends SelfTreeTransformer {
-    import sourceProgram._
+private class RealEnc[Prog <: Program]
+  (val sourceProgram: Prog)
+  (val theory: RealTheory[sourceProgram.trees.type])
+  extends theory.trees.ConcreteSelfTreeTransformer {
+  import theory._
+  import theory.trees._
+  import theory.trees.dsl._
+  import sourceProgram.symbols.{given, _}
 
-    protected def fields(e: Expr): (Expr, Expr) = {
-      val te = transform(e)
-      (te.getField(num), te.getField(denom))
-    }
-
-    override def transform(e: Expr): Expr = e match {
-      case FractionLiteral(num, denom) => fractionCons(E(num), E(denom))
-
-      case Plus(IsTyped(i1, RealType()), i2) =>
-        val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
-        fractionCons(ni1 * di2 + ni2 * di1, di1 * di2)
-
-      case Minus(IsTyped(i1, RealType()), i2) =>
-        val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
-        fractionCons(ni1 * di2 - ni2 * di1, di1 * di2)
-
-      case UMinus(IsTyped(i, RealType())) =>
-        val (ni, di) = fields(i)
-        fractionCons(- ni, di)
-
-      case Times(IsTyped(i1, RealType()), i2) =>
-        val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
-        fractionCons(ni1 * ni2, di1 * di2)
-
-      case Division(IsTyped(i1, RealType()), i2) =>
-        val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
-        fractionCons(ni1 * di2, di1 * ni2)
-
-      case LessThan(IsTyped(i1, RealType()), i2) =>
-        val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
-        ni1 * di2 < di1 * ni2
-
-      case LessEquals(IsTyped(i1, RealType()), i2) =>
-        val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
-        ni1 * di2 <= di1 * ni2
-
-      case GreaterThan(IsTyped(i1, RealType()), i2) =>
-        val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
-        ni1 * di2 > di1 * ni2
-
-      case GreaterEquals(IsTyped(i1, RealType()), i2) =>
-        val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
-        ni1 * di2 >= di1 * ni2
-
-      case _ => super.transform(e)
-    }
-
-    override def transform(tpe: Type): Type = tpe match {
-      case RealType() => fraction()
-      case _ => super.transform(tpe)
-    }
+  protected def fields(e: Expr): (Expr, Expr) = {
+    val te = transform(e)
+    (te.getField(num), te.getField(denom))
   }
 
-  protected object decoder extends SelfTreeTransformer {
-    override def transform(e: Expr): Expr = e match {
-      case ADT(id, Seq(), Seq(IntegerLiteral(num), IntegerLiteral(denom))) if id == fractionCons.id =>
-        exprOps.normalizeFraction(FractionLiteral(num, denom))
-      case _ => super.transform(e)
-    }
+  override def transform(e: Expr): Expr = e match {
+    case FractionLiteral(num, denom) => fractionCons(E(num), E(denom))
 
-    override def transform(tpe: Type): Type = tpe match {
-      case ADTType(`fractionID`, Seq()) => RealType()
-      case _ => super.transform(tpe)
-    }
+    case Plus(IsTyped(i1, RealType()), i2) =>
+      val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
+      fractionCons(ni1 * di2 + ni2 * di1, di1 * di2)
+
+    case Minus(IsTyped(i1, RealType()), i2) =>
+      val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
+      fractionCons(ni1 * di2 - ni2 * di1, di1 * di2)
+
+    case UMinus(IsTyped(i, RealType())) =>
+      val (ni, di) = fields(i)
+      fractionCons(- ni, di)
+
+    case Times(IsTyped(i1, RealType()), i2) =>
+      val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
+      fractionCons(ni1 * ni2, di1 * di2)
+
+    case Division(IsTyped(i1, RealType()), i2) =>
+      val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
+      fractionCons(ni1 * di2, di1 * ni2)
+
+    case LessThan(IsTyped(i1, RealType()), i2) =>
+      val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
+      ni1 * di2 < di1 * ni2
+
+    case LessEquals(IsTyped(i1, RealType()), i2) =>
+      val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
+      ni1 * di2 <= di1 * ni2
+
+    case GreaterThan(IsTyped(i1, RealType()), i2) =>
+      val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
+      ni1 * di2 > di1 * ni2
+
+    case GreaterEquals(IsTyped(i1, RealType()), i2) =>
+      val ((ni1, di1), (ni2, di2)) = (fields(i1), fields(i2))
+      ni1 * di2 >= di1 * ni2
+
+    case _ => super.transform(e)
+  }
+
+  override def transform(tpe: Type): Type = tpe match {
+    case RealType() => fraction()
+    case _ => super.transform(tpe)
+  }
+}
+
+private class RealDec[Prog <: Program]
+  (val sourceProgram: Prog)
+  (val theory: RealTheory[sourceProgram.trees.type])
+  extends theory.trees.ConcreteSelfTreeTransformer {
+  import theory._
+  import theory.trees._
+  import theory.trees.dsl._
+
+  override def transform(e: Expr): Expr = e match {
+    case ADT(id, Seq(), Seq(IntegerLiteral(num), IntegerLiteral(denom))) if id == fractionCons.id =>
+      exprOps.normalizeFraction(FractionLiteral(num, denom))
+    case _ => super.transform(e)
+  }
+
+  override def transform(tpe: Type): Type = tpe match {
+    case ADTType(`fractionID`, Seq()) => RealType()
+    case _ => super.transform(tpe)
   }
 }
 
 object RealEncoder {
-  def apply(p: Program): RealEncoder { val sourceProgram: p.type } = new {
-    val sourceProgram: p.type = p
-  } with RealEncoder
+  def apply(p: Program): RealEncoder { val sourceProgram: p.type } =
+    new RealEncoder(p)(new RealTheory[p.trees.type](p.trees)).asInstanceOf
 }

--- a/src/main/scala/inox/solvers/theories/SetEncoder.scala
+++ b/src/main/scala/inox/solvers/theories/SetEncoder.scala
@@ -6,7 +6,17 @@ package theories
 
 import scala.collection.immutable.{Set => ScalaSet}
 
-trait SetEncoder extends SimpleEncoder {
+class SetEncoder private(override val sourceProgram: Program)
+                        (theory: SetTheory[sourceProgram.trees.type]) extends
+  SimpleEncoder(
+    sourceProgram,
+    new SetEnc[sourceProgram.type](sourceProgram)(theory).asInstanceOf,
+    new SetDec[sourceProgram.type](sourceProgram)(theory).asInstanceOf,
+    theory.extraFunctions,
+    theory.extraSorts
+  )
+
+private class SetTheory[Trees <: ast.Trees](val trees: Trees) {
   import trees._
   import trees.dsl._
 
@@ -27,86 +37,86 @@ trait SetEncoder extends SimpleEncoder {
   val ContainsID = FreshIdentifier("contains")
   val Contains = mkFunDef(ContainsID)("T") { case Seq(aT) => (
     Seq("set" :: Set(aT), "x" :: aT), BooleanType(), {
-      case Seq(set, x) => !set.is(LeafID) && (if_ (set.is(SumID)) {
-        E(ContainsID)(aT)(set.getField(left), x) ||
+    case Seq(set, x) => !set.is(LeafID) && (if_ (set.is(SumID)) {
+      E(ContainsID)(aT)(set.getField(left), x) ||
         E(ContainsID)(aT)(set.getField(right), x)
-      } else_ {
-        set.getField(value) === x
-      })
+    } else_ {
+      set.getField(value) === x
     })
+  })
   }
 
   val RemoveID = FreshIdentifier("remove")
   val Remove = mkFunDef(RemoveID)("T") { case Seq(aT) => (
     Seq("set" :: Set(aT), "x" :: aT), Set(aT), {
-      case Seq(set, x) => if_ (set.is(SumID)) {
-        Sum(aT)(E(RemoveID)(aT)(set.getField(left), x),
-          E(RemoveID)(aT)(set.getField(right), x))
+    case Seq(set, x) => if_ (set.is(SumID)) {
+      Sum(aT)(E(RemoveID)(aT)(set.getField(left), x),
+        E(RemoveID)(aT)(set.getField(right), x))
+    } else_ {
+      if_ (set.is(ElemID) && set.getField(value) === x) {
+        Leaf(aT)()
       } else_ {
-        if_ (set.is(ElemID) && set.getField(value) === x) {
-          Leaf(aT)()
-        } else_ {
-          set
-        }
+        set
       }
-    })
+    }
+  })
   }
 
   val AddID = FreshIdentifier("add")
   val Add = mkFunDef(AddID)("T") { case Seq(aT) => (
     Seq("set" :: Set(aT), "x" :: aT), Set(aT), {
-      case Seq(set, x) => Sum(aT)(set, Elem(aT)(x))
-    })
+    case Seq(set, x) => Sum(aT)(set, Elem(aT)(x))
+  })
   }
 
   val UnionID = FreshIdentifier("union")
   val Union = mkFunDef(UnionID)("T") { case Seq(aT) => (
     Seq("s1" :: Set(aT), "s2" :: Set(aT)), Set(aT), {
-      case Seq(s1, s2) => Sum(aT)(s1, s2)
-    })
+    case Seq(s1, s2) => Sum(aT)(s1, s2)
+  })
   }
 
   val DifferenceID = FreshIdentifier("difference")
   val Difference = mkFunDef(DifferenceID)("T") { case Seq(aT) => (
     Seq("s1" :: Set(aT), "s2" :: Set(aT)), Set(aT), {
-      case Seq(s1, s2) => if_ (s2.is(SumID)) {
-        E(DifferenceID)(aT)(
-          E(DifferenceID)(aT)(s1, s2.getField(left)),
-          s2.getField(right)
-        )
+    case Seq(s1, s2) => if_ (s2.is(SumID)) {
+      E(DifferenceID)(aT)(
+        E(DifferenceID)(aT)(s1, s2.getField(left)),
+        s2.getField(right)
+      )
+    } else_ {
+      if_ (s2.is(ElemID)) {
+        E(RemoveID)(aT)(s1, s2.getField(value))
       } else_ {
-        if_ (s2.is(ElemID)) {
-          E(RemoveID)(aT)(s1, s2.getField(value))
-        } else_ {
-          s1
-        }
+        s1
       }
-    })
+    }
+  })
   }
 
   val IntersectID = FreshIdentifier("intersect")
   val Intersect = mkFunDef(IntersectID)("T") { case Seq(aT) => (
     Seq("s1" :: Set(aT), "s2" :: Set(aT)), Set(aT), {
-      case Seq(s1, s2) => if_ (s1.is(SumID)) {
-        Sum(aT)(E(IntersectID)(aT)(s1.getField(left), s2),
-          E(IntersectID)(aT)(s1.getField(right), s2))
+    case Seq(s1, s2) => if_ (s1.is(SumID)) {
+      Sum(aT)(E(IntersectID)(aT)(s1.getField(left), s2),
+        E(IntersectID)(aT)(s1.getField(right), s2))
+    } else_ {
+      if_ (s1.is(ElemID) && !E(ContainsID)(aT)(s2, s1.getField(value))) {
+        Leaf(aT)()
       } else_ {
-        if_ (s1.is(ElemID) && !E(ContainsID)(aT)(s2, s1.getField(value))) {
-          Leaf(aT)()
-        } else_ {
-          s1
-        }
+        s1
       }
-    })
+    }
+  })
   }
 
   val EqualsID = FreshIdentifier("equals")
   val SetEquals = mkFunDef(EqualsID)("T") { case Seq(aT) => (
     Seq("s1" :: Set(aT), "s2" :: Set(aT)), BooleanType(), {
-      case Seq(s1, s2) => forall("y" :: aT) { y =>
-        E(ContainsID)(aT)(s1, y) === E(ContainsID)(aT)(s2, y)
-      }
-    })
+    case Seq(s1, s2) => forall("y" :: aT) { y =>
+      E(ContainsID)(aT)(s1, y) === E(ContainsID)(aT)(s2, y)
+    }
+  })
   }
 
   val setSort = mkSort(SetID, HasADTEquality(EqualsID))("T") {
@@ -117,91 +127,103 @@ trait SetEncoder extends SimpleEncoder {
     )
   }
 
-  override val extraFunctions = Seq(Contains, Remove, Add, Union, Difference, Intersect, SetEquals)
-  override val extraSorts = Seq(setSort)
+  val extraFunctions = Seq(Contains, Remove, Add, Union, Difference, Intersect, SetEquals)
+  val extraSorts = Seq(setSort)
+}
 
-  protected object encoder extends SelfTreeTransformer {
-    import sourceProgram._
+private class SetEnc[Prog <: Program]
+  (val sourceProgram: Prog)
+  (val theory: SetTheory[sourceProgram.trees.type])
+  extends theory.trees.ConcreteSelfTreeTransformer {
 
-    override def transform(e: Expr): Expr = e match {
-      case FiniteSet(elems, tpe) =>
-        val newTpe = transform(tpe)
-        val newElems = elems.map(transform)
-        newElems.foldLeft(Leaf(newTpe).copiedFrom(e)().copiedFrom(e)) {
-          (acc, x) => Sum(newTpe).copiedFrom(e)(acc, Elem(newTpe).copiedFrom(e)(x).copiedFrom(e)).copiedFrom(e)
-        }
+  import theory._
+  import theory.trees._
+  import theory.trees.dsl._
+  import sourceProgram.symbols.{given, _}
 
-      case SetAdd(set, elem) =>
-        val SetType(base) = set.getType
-        Add(transform(base))(transform(set), transform(elem)).copiedFrom(e)
+  override def transform(e: Expr): Expr = e match {
+    case FiniteSet(elems, tpe) =>
+      val newTpe = transform(tpe)
+      val newElems = elems.map(transform)
+      newElems.foldLeft(Leaf(newTpe).copiedFrom(e)().copiedFrom(e)) {
+        (acc, x) => Sum(newTpe).copiedFrom(e)(acc, Elem(newTpe).copiedFrom(e)(x).copiedFrom(e)).copiedFrom(e)
+      }
 
-      case ElementOfSet(elem, set) =>
-        val SetType(base) = set.getType
-        Contains(transform(base))(transform(set), transform(elem)).copiedFrom(e)
+    case SetAdd(set, elem) =>
+      val SetType(base) = set.getType
+      Add(transform(base))(transform(set), transform(elem)).copiedFrom(e)
 
-      case SetIntersection(s1, s2) =>
-        val SetType(base) = s1.getType
-        Intersect(transform(base))(transform(s1), transform(s2)).copiedFrom(e)
+    case ElementOfSet(elem, set) =>
+      val SetType(base) = set.getType
+      Contains(transform(base))(transform(set), transform(elem)).copiedFrom(e)
 
-      case SetUnion(s1, s2) =>
-        val SetType(base) = s1.getType
-        Union(transform(base))(transform(s1), transform(s2)).copiedFrom(e)
+    case SetIntersection(s1, s2) =>
+      val SetType(base) = s1.getType
+      Intersect(transform(base))(transform(s1), transform(s2)).copiedFrom(e)
 
-      case SetDifference(s1, s2) =>
-        val SetType(base) = s1.getType
-        Difference(transform(base))(transform(s1), transform(s2)).copiedFrom(e)
+    case SetUnion(s1, s2) =>
+      val SetType(base) = s1.getType
+      Union(transform(base))(transform(s1), transform(s2)).copiedFrom(e)
 
-      case _ => super.transform(e)
-    }
+    case SetDifference(s1, s2) =>
+      val SetType(base) = s1.getType
+      Difference(transform(base))(transform(s1), transform(s2)).copiedFrom(e)
 
-    override def transform(tpe: Type): Type = tpe match {
-      case SetType(base) => Set(transform(base)).copiedFrom(tpe)
-      case _ => super.transform(tpe)
-    }
+    case _ => super.transform(e)
   }
 
-  protected object decoder extends SelfTreeTransformer {
-    import targetProgram._
+  override def transform(tpe: Type): Type = tpe match {
+    case SetType(base) => Set(transform(base)).copiedFrom(tpe)
+    case _ => super.transform(tpe)
+  }
+}
 
-    override def transform(e: Expr): Expr = e match {
-      case ADT(SumID, Seq(tpe), Seq(e1, e2)) =>
-        val FiniteSet(els1, _) = transform(e1)
-        val FiniteSet(els2, _) = transform(e2)
-        FiniteSet(els1 ++ els2, transform(tpe)).copiedFrom(e)
+private class SetDec[Prog <: Program]
+  (val sourceProgram: Prog)
+  (val theory: SetTheory[sourceProgram.trees.type])
+  extends theory.trees.ConcreteSelfTreeTransformer {
 
-      case ADT(ElemID, Seq(tpe), Seq(e)) =>
-        FiniteSet(Seq(transform(e)), transform(tpe)).copiedFrom(e)
+  import theory._
+  import theory.trees._
+  import theory.trees.dsl._
 
-      case ADT(LeafID, Seq(tpe), Seq()) =>
-        FiniteSet(Seq.empty, transform(tpe)).copiedFrom(e)
+  override def transform(e: Expr): Expr = e match {
+    case ADT(SumID, Seq(tpe), Seq(e1, e2)) =>
+      val FiniteSet(els1, _) = transform(e1)
+      val FiniteSet(els2, _) = transform(e2)
+      FiniteSet(els1 ++ els2, transform(tpe)).copiedFrom(e)
 
-      case FunctionInvocation(AddID, _, Seq(set, elem)) =>
-        SetAdd(transform(set), transform(elem)).copiedFrom(e)
+    case ADT(ElemID, Seq(tpe), Seq(e)) =>
+      FiniteSet(Seq(transform(e)), transform(tpe)).copiedFrom(e)
 
-      case FunctionInvocation(ContainsID, _, Seq(set, elem)) =>
-        ElementOfSet(transform(elem), transform(set)).copiedFrom(e)
+    case ADT(LeafID, Seq(tpe), Seq()) =>
+      FiniteSet(Seq.empty, transform(tpe)).copiedFrom(e)
 
-      case FunctionInvocation(IntersectID, _, Seq(s1, s2)) =>
-        SetIntersection(transform(s1), transform(s2)).copiedFrom(e)
+    case FunctionInvocation(AddID, _, Seq(set, elem)) =>
+      SetAdd(transform(set), transform(elem)).copiedFrom(e)
 
-      case FunctionInvocation(UnionID, _, Seq(s1, s2)) =>
-        SetUnion(transform(s1), transform(s2)).copiedFrom(e)
+    case FunctionInvocation(ContainsID, _, Seq(set, elem)) =>
+      ElementOfSet(transform(elem), transform(set)).copiedFrom(e)
 
-      case FunctionInvocation(DifferenceID, _, Seq(s1, s2)) =>
-        SetDifference(transform(s1), transform(s2)).copiedFrom(e)
+    case FunctionInvocation(IntersectID, _, Seq(s1, s2)) =>
+      SetIntersection(transform(s1), transform(s2)).copiedFrom(e)
 
-      case _ => super.transform(e)
-    }
+    case FunctionInvocation(UnionID, _, Seq(s1, s2)) =>
+      SetUnion(transform(s1), transform(s2)).copiedFrom(e)
 
-    override def transform(tpe: Type): Type = tpe match {
-      case ADTType(SetID, Seq(base)) => SetType(transform(base)).copiedFrom(tpe)
-      case _ => super.transform(tpe)
-    }
+    case FunctionInvocation(DifferenceID, _, Seq(s1, s2)) =>
+      SetDifference(transform(s1), transform(s2)).copiedFrom(e)
+
+    case _ => super.transform(e)
+  }
+
+  override def transform(tpe: Type): Type = tpe match {
+    case ADTType(SetID, Seq(base)) => SetType(transform(base)).copiedFrom(tpe)
+    case _ => super.transform(tpe)
   }
 }
 
 object SetEncoder {
-  def apply(p: Program): SetEncoder { val sourceProgram: p.type } = new {
-    val sourceProgram: p.type = p
-  } with SetEncoder
+  def apply(p: Program): SetEncoder { val sourceProgram: p.type } =
+    new SetEncoder(p)(new SetTheory[p.trees.type](p.trees)).asInstanceOf
 }

--- a/src/main/scala/inox/solvers/theories/StringEncoder.scala
+++ b/src/main/scala/inox/solvers/theories/StringEncoder.scala
@@ -6,7 +6,19 @@ package theories
 
 import utils._
 
-trait StringEncoder extends SimpleEncoder {
+class StringEncoder private(override val sourceProgram: Program)
+                           (theory: StringTheory[sourceProgram.trees.type],
+                            enc: StringEnc[sourceProgram.type],
+                            dec: StringDec[sourceProgram.type])
+  extends SimpleEncoder(
+    sourceProgram,
+    enc.asInstanceOf,
+    dec.asInstanceOf,
+    theory.extraFunctions,
+    theory.extraSorts
+  )
+
+private class StringTheory[Trees <: ast.Trees](val trees: Trees) {
   import trees._
   import trees.dsl._
 
@@ -30,36 +42,36 @@ trait StringEncoder extends SimpleEncoder {
   val Size = mkFunDef(SizeID)()(_ => (
     Seq("s" :: String),
     IntegerType(), { case Seq(s) =>
-      if_ (s.is(StringConsID)) {
-        E(BigInt(1)) + E(SizeID)(s.getField(tail))
-      } else_ {
-        E(BigInt(0))
-      }
-    }))
+    if_ (s.is(StringConsID)) {
+      E(BigInt(1)) + E(SizeID)(s.getField(tail))
+    } else_ {
+      E(BigInt(0))
+    }
+  }))
 
   val TakeID = FreshIdentifier("take")
   val Take = mkFunDef(TakeID)()(_ => (
     Seq("s" :: String, "i" :: IntegerType()),
     String, { case Seq(s, i) =>
-      if_ (s.is(StringConsID) && i > E(BigInt(0))) {
-        StringCons(
-          s.getField(head),
-          E(TakeID)(s.getField(tail), i - E(BigInt(1))))
-      } else_ {
-        StringNil()
-      }
-    }))
+    if_ (s.is(StringConsID) && i > E(BigInt(0))) {
+      StringCons(
+        s.getField(head),
+        E(TakeID)(s.getField(tail), i - E(BigInt(1))))
+    } else_ {
+      StringNil()
+    }
+  }))
 
   val DropID = FreshIdentifier("drop")
   val Drop = mkFunDef(DropID)()(_ => (
     Seq("s" :: String, "i" :: IntegerType()),
     String, { case Seq(s, i) =>
-      if_ (s.is(StringConsID) && i > E(BigInt(0))) {
-        E(DropID)(s.getField(tail), i - E(BigInt(1)))
-      } else_ {
-        s
-      }
-    }))
+    if_ (s.is(StringConsID) && i > E(BigInt(0))) {
+      E(DropID)(s.getField(tail), i - E(BigInt(1)))
+    } else_ {
+      s
+    }
+  }))
 
   val SliceID = FreshIdentifier("slice")
   val Slice = mkFunDef(SliceID)()(_ => (
@@ -70,78 +82,100 @@ trait StringEncoder extends SimpleEncoder {
   val Concat = mkFunDef(ConcatID)()(_ => (
     Seq("s1" :: String, "s2" :: String),
     String, { case Seq(s1, s2) =>
-      if_ (s1.is(StringConsID)) {
-        StringCons(
-          s1.getField(head),
-          E(ConcatID)(s1.getField(tail), s2))
-      } else_ {
-        s2
-      }
-    }))
+    if_ (s1.is(StringConsID)) {
+      StringCons(
+        s1.getField(head),
+        E(ConcatID)(s1.getField(tail), s2))
+    } else_ {
+      s2
+    }
+  }))
 
-  override val extraFunctions = Seq(Size, Take, Drop, Slice, Concat)
-  override val extraSorts = Seq(stringSort)
+  val extraFunctions = Seq(Size, Take, Drop, Slice, Concat)
+  val extraSorts = Seq(stringSort)
+}
 
-  private val stringBijection = new Bijection[String, Expr]()
+private class StringEnc[Prog <: Program]
+  (val sourceProgram: Prog)
+  (val theory: StringTheory[sourceProgram.trees.type],
+   val stringBijection: Bijection[String, sourceProgram.trees.Expr])
+  extends theory.trees.ConcreteSelfTreeTransformer {
+
+  import theory._
+  import theory.trees._
+  import theory.trees.dsl._
+
+  override def transform(e: Expr): Expr = e match {
+    case StringLiteral(v) => convertFromString(v)
+    case StringLength(a) => Size(transform(a)).copiedFrom(e)
+    case StringConcat(a, b) => Concat(transform(a), transform(b)).copiedFrom(e)
+    case SubString(a, start, Plus(start2, length)) if start == start2  =>
+      Take(Drop(transform(a), transform(start)), transform(length)).copiedFrom(e)
+    case SubString(a, start, end) =>
+      Slice(transform(a), transform(start), transform(end)).copiedFrom(e)
+    case _ => super.transform(e)
+  }
+
+  override def transform(tpe: Type): Type = tpe match {
+    case StringType() => String
+    case _ => super.transform(tpe)
+  }
+
+  private def convertFromString(v: String): Expr = stringBijection.cachedB(v) {
+    v.toList.foldRight(StringNil()){ case (char, l) => StringCons(E(char), l) }
+  }
+}
+
+private class StringDec[Prog <: Program]
+  (val sourceProgram: Prog)
+  (val theory: StringTheory[sourceProgram.trees.type],
+   val stringBijection: Bijection[String, sourceProgram.trees.Expr])
+  extends theory.trees.ConcreteSelfTreeTransformer {
+
+  import theory._
+  import theory.trees._
+  import theory.trees.dsl._
+
+  override def transform(e: Expr): Expr = e match {
+    case cc @ ADT(StringNilID | StringConsID, Seq(), args) =>
+      StringLiteral(convertToString(cc)).copiedFrom(cc)
+    case FunctionInvocation(SizeID, Seq(), Seq(a)) =>
+      StringLength(transform(a)).copiedFrom(e)
+    case FunctionInvocation(ConcatID, Seq(), Seq(a, b)) =>
+      StringConcat(transform(a), transform(b)).copiedFrom(e)
+    case FunctionInvocation(SliceID, Seq(), Seq(a, from, to)) =>
+      SubString(transform(a), transform(from), transform(to)).copiedFrom(e)
+    case FunctionInvocation(TakeID, Seq(), Seq(FunctionInvocation(DropID, Seq(), Seq(a, start)), length)) =>
+      val rstart = transform(start)
+      SubString(transform(a), rstart, Plus(rstart, transform(length))).copiedFrom(e)
+    case FunctionInvocation(TakeID, Seq(), Seq(a, length)) =>
+      SubString(transform(a), IntegerLiteral(0), transform(length)).copiedFrom(e)
+    case FunctionInvocation(DropID, Seq(), Seq(a, count)) =>
+      val ra = transform(a)
+      SubString(ra, transform(count), StringLength(ra)).copiedFrom(e)
+    case _ => super.transform(e)
+  }
+
+  override def transform(tpe: Type): Type = tpe match {
+    case String => StringType()
+    case _ => super.transform(tpe)
+  }
 
   private def convertToString(e: Expr): String  = stringBijection.cachedA(e)(e match {
     // Do not call toString on the char but rather String.valueOf because toString messes things up with UTF-8 codepoints
     case ADT(StringConsID, Seq(), Seq(CharLiteral(c), l)) => java.lang.String.valueOf(if(c < 31) (c + 97).toChar else c) + convertToString(l)
     case ADT(StringNilID, Seq(), Seq()) => ""
   })
-
-  private def convertFromString(v: String): Expr = stringBijection.cachedB(v) {
-    v.toList.foldRight(StringNil()){ case (char, l) => StringCons(E(char), l) }
-  }
-
-  protected object encoder extends SelfTreeTransformer {
-    override def transform(e: Expr): Expr = e match {
-      case StringLiteral(v) => convertFromString(v)
-      case StringLength(a) => Size(transform(a)).copiedFrom(e)
-      case StringConcat(a, b) => Concat(transform(a), transform(b)).copiedFrom(e)
-      case SubString(a, start, Plus(start2, length)) if start == start2  =>
-        Take(Drop(transform(a), transform(start)), transform(length)).copiedFrom(e)
-      case SubString(a, start, end) => 
-        Slice(transform(a), transform(start), transform(end)).copiedFrom(e)
-      case _ => super.transform(e)
-    }
-
-    override def transform(tpe: Type): Type = tpe match {
-      case StringType() => String
-      case _ => super.transform(tpe)
-    }
-  }
-
-  protected object decoder extends SelfTreeTransformer {
-    override def transform(e: Expr): Expr = e match {
-      case cc @ ADT(StringNilID | StringConsID, Seq(), args) =>
-        StringLiteral(convertToString(cc)).copiedFrom(cc)
-      case FunctionInvocation(SizeID, Seq(), Seq(a)) =>
-        StringLength(transform(a)).copiedFrom(e)
-      case FunctionInvocation(ConcatID, Seq(), Seq(a, b)) =>
-        StringConcat(transform(a), transform(b)).copiedFrom(e)
-      case FunctionInvocation(SliceID, Seq(), Seq(a, from, to)) =>
-        SubString(transform(a), transform(from), transform(to)).copiedFrom(e)
-      case FunctionInvocation(TakeID, Seq(), Seq(FunctionInvocation(DropID, Seq(), Seq(a, start)), length)) =>
-        val rstart = transform(start)
-        SubString(transform(a), rstart, Plus(rstart, transform(length))).copiedFrom(e)
-      case FunctionInvocation(TakeID, Seq(), Seq(a, length)) =>
-        SubString(transform(a), IntegerLiteral(0), transform(length)).copiedFrom(e)
-      case FunctionInvocation(DropID, Seq(), Seq(a, count)) =>
-        val ra = transform(a)
-        SubString(ra, transform(count), StringLength(ra)).copiedFrom(e)
-      case _ => super.transform(e)
-    }
-
-    override def transform(tpe: Type): Type = tpe match {
-      case String | StringCons | StringNil => StringType()
-      case _ => super.transform(tpe)
-    }
-  }
 }
 
 object StringEncoder {
-  def apply(p: Program): StringEncoder { val sourceProgram: p.type } = new {
-    val sourceProgram: p.type = p
-  } with StringEncoder
+  def apply(p: Program): StringEncoder { val sourceProgram: p.type } = {
+    val stringBijection = new Bijection[String, p.trees.Expr]()
+    val theory = new StringTheory[p.trees.type](p.trees)
+    val enc = new StringEnc[p.type](p)(theory, stringBijection)
+    val dec = new StringDec[p.type](p)(theory, stringBijection)
+    // For some reason, we need to explicitly type `StringEncoder { val sourceProgram: p.type }` in the asInstanceOf,
+    // otherwise it tries to cast the expression to Nothing (such problem does not arise in other cases!)
+    (new StringEncoder(p)(theory, enc, dec)).asInstanceOf[StringEncoder { val sourceProgram: p.type }]
+  }
 }

--- a/src/main/scala/inox/solvers/theories/TheoryEncoder.scala
+++ b/src/main/scala/inox/solvers/theories/TheoryEncoder.scala
@@ -4,29 +4,49 @@ package inox
 package solvers
 package theories
 
+import inox.transformers.TreeTransformer
 import utils._
 
 trait TheoryEncoder extends transformers.ProgramTransformer { self =>
   val targetProgram: Program { val trees: sourceProgram.trees.type }
-  lazy val trees: sourceProgram.trees.type = sourceProgram.trees
+  val trees: sourceProgram.trees.type = sourceProgram.trees
 }
 
-trait SimpleEncoder extends TheoryEncoder with transformers.ProgramEncoder {
-  val t: sourceProgram.trees.type = sourceProgram.trees
+abstract class SimpleEncoder private(override val sourceProgram: Program)
+                                    (override val t: sourceProgram.trees.type)
+                                    (override protected val encoder: transformers.TreeTransformer {
+                                      val s: sourceProgram.trees.type
+                                      val t: sourceProgram.trees.type
+                                    },
+                                    override protected val decoder: transformers.TreeTransformer {
+                                      val s: sourceProgram.trees.type
+                                      val t: sourceProgram.trees.type
+                                    },
+                                    extraFunctions: Seq[t.FunDef],
+                                    extraSorts: Seq[t.ADTSort])
+  extends transformers.ProgramEncoder(t, sourceProgram, encoder, decoder)(extraFunctions = extraFunctions, extraSorts = extraSorts)
+     with TheoryEncoder {
+  def this(sourceProgram: Program,
+           encoder: transformers.TreeTransformer {
+             val s: sourceProgram.trees.type
+             val t: sourceProgram.trees.type
+           },
+           decoder: transformers.TreeTransformer {
+             val s: sourceProgram.trees.type
+             val t: sourceProgram.trees.type
+           },
+           extraFunctions: Seq[sourceProgram.trees.FunDef] = Seq.empty,
+           extraSorts: Seq[sourceProgram.trees.ADTSort] = Seq.empty) =
+    this(sourceProgram)(sourceProgram.trees)(encoder, decoder, extraFunctions, extraSorts)
 }
 
-object NoEncoder {
-  def apply(p: Program, ctx: Context): TheoryEncoder {
-    val sourceProgram: p.type
-    val targetProgram: Program { val trees: p.trees.type }
-  } = new TheoryEncoder {
-    val sourceProgram: p.type = p
-    val targetProgram: Program { val trees: p.trees.type } =
-      p.asInstanceOf[Program { val trees: p.trees.type }]
+class NoEncoder private(val p: Program)
+                       (override val sourceProgram: p.type,
+                        override val targetProgram: Program { val trees: p.trees.type },
+                        override val encoder: p.trees.ConcreteIdentityTreeTransformer,
+                        override val decoder: p.trees.ConcreteIdentityTreeTransformer)
+  extends TheoryEncoder with transformers.ProgramTransformer {
 
-    import trees._
-    protected object encoder extends IdentityTreeTransformer
-    protected object decoder extends IdentityTreeTransformer
-  }
+  def this(p: Program) =
+    this(p)(p, p.asInstanceOf[Program { val trees: p.trees.type }], new p.trees.ConcreteIdentityTreeTransformer, new p.trees.ConcreteIdentityTreeTransformer)
 }
-

--- a/src/main/scala/inox/solvers/theories/package.scala
+++ b/src/main/scala/inox/solvers/theories/package.scala
@@ -55,20 +55,21 @@ package object theories {
   object ReverseEvaluator {
     def apply(enc: ProgramTransformer)
              (ev: DeterministicEvaluator { val program: enc.sourceProgram.type }):
-             DeterministicEvaluator { val program: enc.targetProgram.type } = new {
-      val program: enc.targetProgram.type = enc.targetProgram
-      val context = ev.context
-    } with DeterministicEvaluator {
-      import program.trees._
-      import EvaluationResults._
+             DeterministicEvaluator { val program: enc.targetProgram.type } = {
+      class ReverseEvaluatorImpl(override val program: enc.targetProgram.type,
+                                 override val context: inox.Context) extends DeterministicEvaluator {
+        import program.trees._
+        import EvaluationResults._
 
-      def eval(e: Expr, model: program.Model): EvaluationResult = {
-        ev.eval(enc.decode(e), model.encode(enc.reverse)) match {
-          case Successful(value) => Successful(enc.encode(value))
-          case RuntimeError(message) => RuntimeError(message)
-          case EvaluatorError(message) => EvaluatorError(message)
+        def eval(e: Expr, model: program.Model): EvaluationResult = {
+          ev.eval(enc.decode(e), model.encode(enc.reverse)) match {
+            case Successful(value) => Successful(enc.encode(value))
+            case RuntimeError(message) => RuntimeError(message)
+            case EvaluatorError(message) => EvaluatorError(message)
+          }
         }
       }
+      new ReverseEvaluatorImpl(enc.targetProgram, ev.context)
     }
   }
 }

--- a/src/main/scala/inox/solvers/unrolling/EqualityTemplates.scala
+++ b/src/main/scala/inox/solvers/unrolling/EqualityTemplates.scala
@@ -14,10 +14,10 @@ import scala.collection.mutable.{Set => MutableSet, Map => MutableMap}
   * @see [[ast.Definitions.ADTSort.equality]] for such a case of equality
   */
 trait EqualityTemplates { self: Templates =>
-  import context._
+  import context.{given, _}
   import program._
   import program.trees._
-  import program.symbols._
+  import program.symbols.{given, _}
 
   import equalityManager._
 
@@ -96,7 +96,7 @@ trait EqualityTemplates { self: Templates =>
       val pathVar = Variable.fresh("b", BooleanType(), true)
       val pathVarT = encodeSymbol(pathVar)
 
-      val tmplClauses = mkClauses(pathVar, Equals(Application(f, args), tpe match {
+      val tmplClauses = mkClauses0(pathVar, Equals(Application(f, args), tpe match {
         case adt: ADTType =>
           val sort = adt.getSort
 

--- a/src/main/scala/inox/solvers/unrolling/FunctionTemplates.scala
+++ b/src/main/scala/inox/solvers/unrolling/FunctionTemplates.scala
@@ -9,10 +9,10 @@ import utils._
 import scala.collection.mutable.{Set => MutableSet, Map => MutableMap}
 
 trait FunctionTemplates { self: Templates =>
-  import context._
+  import context.{given, _}
   import program._
   import program.trees._
-  import program.symbols._
+  import program.symbols.{given, _}
 
   import functionsManager._
   import lambdasManager._
@@ -21,7 +21,7 @@ trait FunctionTemplates { self: Templates =>
     val free = typeOps.variablesOf(tpe)
     val vars = new scala.collection.mutable.ListBuffer[Variable]
 
-    new SelfTreeTraverser {
+    new ConcreteSelfTreeTraverser {
       override def traverse(e: Expr): Unit = e match {
         case v: Variable if free(v) => vars += v
         case _ => super.traverse(e)
@@ -127,7 +127,7 @@ trait FunctionTemplates { self: Templates =>
     // also specify the generation of the blocker.
     private[FunctionTemplates] val callInfos   = new IncrementalMap[Encoded, (Int, Int, Encoded, Set[Call])]()
 
-    private lazy val evaluator = semantics.getEvaluator(context.withOpts(evaluators.optEvalQuantifiers(false)))
+    private lazy val evaluator = semantics.getEvaluator(using context.withOpts(evaluators.optEvalQuantifiers(false)))
 
     val incrementals: Seq[IncrementalState] = Seq(callInfos, defBlockers)
 

--- a/src/main/scala/inox/solvers/unrolling/LambdaTemplates.scala
+++ b/src/main/scala/inox/solvers/unrolling/LambdaTemplates.scala
@@ -8,10 +8,10 @@ import utils._
 import scala.collection.mutable.{Map => MutableMap, Set => MutableSet}
 
 trait LambdaTemplates { self: Templates =>
-  import context._
+  import context.{given, _}
   import program._
   import program.trees._
-  import program.symbols._
+  import program.symbols.{given, _}
 
   import typesManager._
   import lambdasManager._

--- a/src/main/scala/inox/solvers/unrolling/TypeTemplates.scala
+++ b/src/main/scala/inox/solvers/unrolling/TypeTemplates.scala
@@ -21,10 +21,10 @@ import scala.collection.mutable.{Map => MutableMap, Set => MutableSet}
   *                          and the total ordering of closures.
   */
 trait TypeTemplates { self: Templates =>
-  import context._
+  import context.{given, _}
   import program._
   import program.trees._
-  import program.symbols._
+  import program.symbols.{given, _}
 
   import typesManager._
 
@@ -185,7 +185,7 @@ trait TypeTemplates { self: Templates =>
 
       val substMap = Map(v -> idT, pathVar -> pathVarT) ++ arguments
 
-      implicit val generator = if (free) FreeGenerator else ContractGenerator
+      given TypingGenerator = if (free) FreeGenerator else ContractGenerator
       val (p, tmplClauses) = mkTypeClauses(pathVar, tpe, v, substMap)
       val (contents, _) = Template.contents(
         pathVar -> pathVarT, Seq(result -> resultT, v -> idT) ++ arguments,
@@ -254,7 +254,7 @@ trait TypeTemplates { self: Templates =>
       val container = Variable.fresh("container", containerType, true)
       val containerT = encodeSymbol(container)
 
-      implicit val generator = CaptureGenerator(containerT, containerType)
+      given CaptureGenerator = CaptureGenerator(containerT, containerType)
       val (p, tmplClauses) = mkTypeClauses(pathVar, tpe, v, substMap)
       val (condVars, exprVars, _, _, _, types, equalities, lambdas, quants) = tmplClauses
       assert(equalities.isEmpty && lambdas.isEmpty && quants.isEmpty,

--- a/src/main/scala/inox/solvers/unrolling/UnrollingOptimizer.scala
+++ b/src/main/scala/inox/solvers/unrolling/UnrollingOptimizer.scala
@@ -7,7 +7,7 @@ package unrolling
 trait AbstractUnrollingOptimizer extends AbstractUnrollingSolver with Optimizer { self =>
   import program._
   import program.trees._
-  import program.symbols._
+  import program.symbols.{given, _}
 
   protected val underlying: AbstractOptimizer {
     val program: targetProgram.type

--- a/src/main/scala/inox/solvers/z3/AbstractZ3Solver.scala
+++ b/src/main/scala/inox/solvers/z3/AbstractZ3Solver.scala
@@ -16,7 +16,7 @@ trait AbstractZ3Solver
 
   import program._
   import program.trees._
-  import program.symbols._
+  import program.symbols.{given, _}
 
   import SolverResponses._
 
@@ -56,7 +56,7 @@ trait AbstractZ3Solver
       case None => Unknown
     }).getOrElse(Unknown))
 
-  def check(config: CheckConfiguration) = extractResult(config)(solver.check())
+  def check(config: CheckConfiguration): config.Response[Z3Model, Set[Z3AST]] = extractResult(config)(solver.check())
   def checkAssumptions(config: Configuration)(assumptions: Set[Z3AST]) =
     extractResult(config)(solver.checkAssumptions(assumptions.toSeq : _*))
 }

--- a/src/main/scala/inox/solvers/z3/NativeZ3Solver.scala
+++ b/src/main/scala/inox/solvers/z3/NativeZ3Solver.scala
@@ -10,16 +10,23 @@ import z3.scala._
 
 object NativeZ3Solver
 
-trait NativeZ3Solver extends Z3Unrolling { self =>
+class NativeZ3Solver(prog: Program,
+                     context: Context,
+                     enc: transformers.ProgramTransformer {val sourceProgram: prog.type},
+                     chooses: ChooseEncoder {val program: prog.type; val sourceEncoder: enc.type})
+                    (using semantics: prog.Semantics,
+                     semanticsProvider: SemanticsProvider {val trees: enc.targetProgram.trees.type})
+  extends Z3Unrolling(prog, context, enc, chooses) { self =>
 
   override val name = "nativez3"
 
-  protected val underlying = NativeZ3Solver.synchronized(new {
-    val program: targetProgram.type = targetProgram
-    val context = self.context
-  } with AbstractZ3Solver {
-    lazy val semantics = targetSemantics
-  })
+  protected val underlying =
+    NativeZ3Solver.synchronized(new Underlying(targetProgram, self.context)(using targetSemantics))
 
   override def free(): Unit = NativeZ3Solver.synchronized(super.free())
+
+  private class Underlying(override val program: targetProgram.type,
+                           override val context: Context)
+                          (using override val semantics: targetSemantics.type)
+    extends AbstractZ3Solver
 }

--- a/src/main/scala/inox/tip/TipDebugger.scala
+++ b/src/main/scala/inox/tip/TipDebugger.scala
@@ -28,7 +28,7 @@ trait TipDebugger extends Solver {
 
     import inox.trees._
 
-    protected object checker extends SelfTreeTraverser {
+    protected object checker extends ConcreteSelfTreeTraverser {
       override def traverse(tpe: Type): Unit = tpe match {
         case (_: PiType | _: SigmaType | _: RefinementType) =>
           unsupported(tpe, "Dependent types cannot be expressed in TIP")
@@ -62,7 +62,7 @@ trait TipDebugger extends Solver {
   }
 
   protected lazy val debugOut: Option[tip.Printer] = {
-    implicit val debugSection: DebugSection = DebugSectionTip
+    given DebugSection = DebugSectionTip
 
     if (context.reporter.isDebugEnabled) {
       val files = context.options.findOptionOrDefault(Main.optFiles)

--- a/src/main/scala/inox/transformers/ProgramTransformer.scala
+++ b/src/main/scala/inox/transformers/ProgramTransformer.scala
@@ -32,77 +32,102 @@ trait ProgramTransformer { self =>
   def compose(that: ProgramTransformer { val targetProgram: self.sourceProgram.type }): ProgramTransformer {
     val sourceProgram: that.sourceProgram.type
     val targetProgram: self.targetProgram.type
-  } = new ProgramTransformer {
-    val sourceProgram: that.sourceProgram.type = that.sourceProgram
-    val targetProgram: self.targetProgram.type = self.targetProgram
+  } = {
+    val enc = self.encoder compose that.encoder
+    val dec = that.decoder compose self.decoder
+    class ComposeImpl(override val sourceProgram: that.sourceProgram.type,
+                      override val targetProgram: self.targetProgram.type,
+                      override val encoder: enc.type,
+                      override val decoder: dec.type) extends ProgramTransformer
 
-    protected val encoder = self.encoder compose that.encoder
-    protected val decoder = that.decoder compose self.decoder
+    new ComposeImpl(that.sourceProgram, self.targetProgram, enc, dec)
   }
 
   def andThen(that: ProgramTransformer { val sourceProgram: self.targetProgram.type }): ProgramTransformer {
     val sourceProgram: self.sourceProgram.type
     val targetProgram: that.targetProgram.type
-  } = new ProgramTransformer {
-    val sourceProgram: self.sourceProgram.type = self.sourceProgram
-    val targetProgram: that.targetProgram.type = that.targetProgram
+  } = {
+    val enc = self.encoder andThen that.encoder
+    val dec = that.decoder andThen self.decoder
+    class AndThenImpl(override val sourceProgram: self.sourceProgram.type,
+                      override val targetProgram: that.targetProgram.type,
+                      override val encoder: enc.type,
+                      override val decoder: dec.type) extends ProgramTransformer
 
-    protected val encoder = self.encoder andThen that.encoder
-    protected val decoder = that.decoder andThen self.decoder
+    new AndThenImpl(self.sourceProgram, that.targetProgram, enc, dec)
   }
 
   def reverse: ProgramTransformer {
     val sourceProgram: self.targetProgram.type
     val targetProgram: self.sourceProgram.type
-  } = new ProgramTransformer {
-    val sourceProgram: self.targetProgram.type = self.targetProgram
-    val targetProgram: self.sourceProgram.type = self.sourceProgram
+  } = {
+    class ReverseImpl(override val sourceProgram: self.targetProgram.type,
+                      override val targetProgram: self.sourceProgram.type,
+                      override val encoder: self.decoder.type,
+                      override val decoder: self.encoder.type) extends ProgramTransformer
 
-    protected val encoder = self.decoder
-    protected val decoder = self.encoder
+    new ReverseImpl(self.targetProgram, self.sourceProgram, self.decoder, self.encoder)
   }
 }
 
-trait ProgramEncoder extends ProgramTransformer { self =>
-  lazy final val s: sourceProgram.trees.type = sourceProgram.trees
-  val t: ast.Trees
+abstract class ProgramEncoder private(val t: ast.Trees)
+                                     (override val sourceProgram: Program,
+                                      override val targetProgram: Program { val trees: t.type })
+                                     (override protected val encoder: transformers.TreeTransformer {
+                                        val s: sourceProgram.trees.type
+                                        val t: targetProgram.trees.type
+                                      },
+                                      override protected val decoder: transformers.TreeTransformer {
+                                        val s: targetProgram.trees.type
+                                        val t: sourceProgram.trees.type
+                                      })
+  extends ProgramTransformer { self =>
+  final val s: sourceProgram.trees.type = sourceProgram.trees
 
-  protected val extraFunctions: Seq[t.FunDef] = Seq.empty
-  protected val extraSorts: Seq[t.ADTSort] = Seq.empty
-
-  /** Override point for more complex program transformations */
-  protected def encodedProgram: Program { val trees: t.type } = {
-    sourceProgram.transform(SymbolTransformer(encoder))
-  }
-
-  lazy final val targetProgram: Program { val trees: t.type } = {
-    encodedProgram.withFunctions(extraFunctions).withSorts(extraSorts)
-  }
+  def this(tt: ast.Trees,
+           sourceProgram: Program,
+           encoder: transformers.TreeTransformer {
+             val s: sourceProgram.trees.type
+             val t: tt.type
+           },
+           decoder: transformers.TreeTransformer {
+             val s: tt.type
+             val t: sourceProgram.trees.type
+           })
+          (encodedProgram: Program { val trees: tt.type } = sourceProgram.transform(SymbolTransformer(encoder)),
+           extraFunctions: Seq[tt.FunDef] = Seq.empty,
+           extraSorts: Seq[tt.ADTSort] = Seq.empty) =
+    this(tt)(
+      sourceProgram,
+      // Note that targetProgram will always be equal to this expression.
+      // The only parts that can be customized are encodedProgram, extraFunctions and extraSorts,
+      // which all have reasonable default values.
+      encodedProgram.withFunctions(extraFunctions).withSorts(extraSorts)
+    )(encoder, decoder)
 }
 
 object ProgramEncoder {
   def empty(p: Program): ProgramEncoder {
     val sourceProgram: p.type
     val t: p.trees.type
-  } = new ProgramEncoder {
-    val sourceProgram: p.type = p
-    val t: p.trees.type = p.trees
+  } = {
+    val identity = new p.trees.ConcreteIdentityTreeTransformer
+    class EmptyImpl(override val t: p.trees.type, override val sourceProgram: p.type)
+      extends ProgramEncoder(t, sourceProgram, identity, identity)()
 
-    protected object encoder extends p.trees.IdentityTreeTransformer
-    protected object decoder extends p.trees.IdentityTreeTransformer
+    new EmptyImpl(p.trees, p)
   }
 
   def apply(p: Program)(tr: SymbolTransformer { val s: p.trees.type; val t: p.trees.type }): ProgramEncoder {
     val sourceProgram: p.type
     val t: p.trees.type
-  } = new ProgramEncoder {
-    val sourceProgram: p.type = p
-    val t: p.trees.type = p.trees
+    val targetProgram: Program { val trees: p.trees.type }
+  } = {
+    val identity = new p.trees.ConcreteIdentityTreeTransformer
+    class Impl(override val t: p.trees.type, override val sourceProgram: p.type)
+      extends ProgramEncoder(t, sourceProgram, identity, identity)(p.transform(tr))
 
-    override protected def encodedProgram: Program { val trees: p.trees.type } = p.transform(tr)
-
-    protected object encoder extends p.trees.IdentityTreeTransformer
-    protected object decoder extends p.trees.IdentityTreeTransformer
+    new Impl(p.trees, p)
   }
 }
 

--- a/src/main/scala/inox/transformers/SimplifierWithPath.scala
+++ b/src/main/scala/inox/transformers/SimplifierWithPath.scala
@@ -7,7 +7,7 @@ import utils._
 
 trait SimplifierWithPath extends SimplifierWithPC {
   import trees._
-  import symbols._
+  import symbols.{given, _}
 
   class Env private(
     private val conditions: Set[Expr],
@@ -43,7 +43,7 @@ trait SimplifierWithPath extends SimplifierWithPC {
     override def toString: String = conditions.toString
   }
 
-  implicit object Env extends PathProvider[Env] {
+  object Env extends PathProvider[Env] {
     def empty = new Env(Set(), Map())
   }
 

--- a/src/main/scala/inox/transformers/SymbolTransformer.scala
+++ b/src/main/scala/inox/transformers/SymbolTransformer.scala
@@ -10,31 +10,29 @@ trait SymbolTransformer { self =>
 
   def transform(syms: s.Symbols): t.Symbols
 
-  /** Enables equality checks between symbol transformer compositions */
-  protected trait SymbolTransformerComposition extends SymbolTransformer {
-    protected val lhs: SymbolTransformer
-    protected val rhs: SymbolTransformer { val t: lhs.s.type }
-
-    val s: rhs.s.type = rhs.s
-    val t: lhs.t.type = lhs.t
-
-    override def transform(syms: s.Symbols): t.Symbols = lhs.transform(rhs.transform(syms))
-
-    override def equals(that: Any): Boolean = that match {
-      case c: SymbolTransformerComposition => rhs == c.rhs && lhs == c.lhs
-      case _ => false
-    }
-
-    override def hashCode: Int = 31 * rhs.hashCode + lhs.hashCode
-  }
-
   def compose(that: SymbolTransformer { val t: self.s.type }): SymbolTransformer {
     val s: that.s.type
     val t: self.t.type
-  } = new {
-    val rhs: that.type = that
-    val lhs: self.type = self
-  } with SymbolTransformerComposition
+  } = {
+    /** Enables equality checks between symbol transformer compositions */
+    class SymbolTransformerComposition(protected val lhs: self.type,
+                                       protected val rhs: that.type)
+                                      (override val s: rhs.s.type,
+                                       override val t: self.t.type)
+      extends SymbolTransformer {
+
+      override def transform(syms: s.Symbols): t.Symbols = lhs.transform(rhs.transform(syms))
+
+      override def equals(that: Any): Boolean = that match {
+        case c: SymbolTransformerComposition => rhs == c.rhs && lhs == c.lhs
+        case _ => false
+      }
+
+      override def hashCode: Int = 31 * rhs.hashCode + lhs.hashCode
+    }
+
+    new SymbolTransformerComposition(self, that)(that.s, self.t)
+  }
 
   def andThen(that: SymbolTransformer {
     val s: self.t.type
@@ -63,11 +61,13 @@ object SymbolTransformer {
   def apply(trans: DefinitionTransformer): SymbolTransformer {
     val s: trans.s.type
     val t: trans.t.type
-  } = new SimpleSymbolTransformer {
-    val s: trans.s.type = trans.s
-    val t: trans.t.type = trans.t
-
-    protected def transformFunction(fd: s.FunDef): t.FunDef = trans.transform(fd)
-    protected def transformSort(sort: s.ADTSort): t.ADTSort = trans.transform(sort)
+  } = {
+    class Impl(override val s: trans.s.type,
+               override val t: trans.t.type)
+      extends SimpleSymbolTransformer {
+      protected def transformFunction(fd: s.FunDef): t.FunDef = trans.transform(fd)
+      protected def transformSort(sort: s.ADTSort): t.ADTSort = trans.transform(sort)
+    }
+    new Impl(trans.s, trans.t)
   }
 }

--- a/src/main/scala/inox/transformers/TransformerOps.scala
+++ b/src/main/scala/inox/transformers/TransformerOps.scala
@@ -10,7 +10,7 @@ class TransformerOp[In, Env, Out](val app: (In, Env) => Out, val sup: (In, Env) 
 trait TransformerWithExprOp extends Transformer {
   private[this] val op = new TransformerOp[s.Expr, Env, t.Expr](transform(_, _), super.transform(_, _))
 
-  protected val exprOp: (s.Expr, Env, TransformerOp[s.Expr, Env, t.Expr]) => t.Expr
+  protected def exprOp(expr: s.Expr, env: Env, op: TransformerOp[s.Expr, Env, t.Expr]): t.Expr
 
   override def transform(e: s.Expr, env: Env): t.Expr = exprOp(e, env, op)
 }
@@ -18,7 +18,7 @@ trait TransformerWithExprOp extends Transformer {
 trait TransformerWithTypeOp extends Transformer {
   private[this] val op = new TransformerOp[s.Type, Env, t.Type](transform(_, _), super.transform(_, _))
 
-  protected val typeOp: (s.Type, Env, TransformerOp[s.Type, Env, t.Type]) => t.Type
+  protected def typeOp(ty: s.Type, env: Env, op: TransformerOp[s.Type, Env, t.Type]): t.Type
 
   override def transform(tpe: s.Type, env: Env): t.Type = typeOp(tpe, env, op)
 }

--- a/src/main/scala/inox/utils/Caches.scala
+++ b/src/main/scala/inox/utils/Caches.scala
@@ -28,7 +28,7 @@ class LruCache[A,B](val maxSize: Int) extends Cache[A,B] {
   def clear(): Unit = cache.clear()
 }
 
-class PriorityCache[A,B](val maxSize: Int)(implicit val ordering: Ordering[A]) extends Cache[A,B] {
+class PriorityCache[A,B](val maxSize: Int)(using val ordering: Ordering[A]) extends Cache[A,B] {
   private[this] val cache = new java.util.HashMap[A,B](maxSize + 1)
   private[this] val queue = new java.util.PriorityQueue(maxSize, ordering)
 

--- a/src/main/scala/inox/utils/GraphPrinters.scala
+++ b/src/main/scala/inox/utils/GraphPrinters.scala
@@ -45,7 +45,7 @@ object GraphPrinters {
     def highlight(f: N => Boolean) = colorize(f, "red")
 
 
-    def drawNode(n: N)(implicit res: StringBuffer): Unit = {
+    def drawNode(n: N)(using res: StringBuffer): Unit = {
       var opts = Map[String, String]()
       opts += "label" -> ("\"" + dot.escape(nToLabel(n)) + "\"")
 
@@ -64,7 +64,7 @@ object GraphPrinters {
       dot.uniqueName("e", e)
     }
 
-    def drawEdge(e: E)(implicit res: StringBuffer): Unit = {
+    def drawEdge(e: E)(using res: StringBuffer): Unit = {
       e match {
         case le: LabeledEdge[_, N] =>
           res append dot.box(eToS(e), le.l.toString)
@@ -76,8 +76,8 @@ object GraphPrinters {
     }
 
     def asString(g: G): String = {
-      implicit val res = new StringBuffer()
-
+      val res = new StringBuffer()
+      given StringBuffer = res
       res append "digraph D {\n"
 
       g.N.foreach(drawNode)

--- a/src/main/scala/inox/utils/Graphs.scala
+++ b/src/main/scala/inox/utils/Graphs.scala
@@ -6,12 +6,12 @@ package utils
 import scala.Iterable
 object Graphs {
   trait EdgeLike[Node] {
-    def _1: Node
-    def _2: Node
+    val _1: Node
+    val _2: Node
   }
 
   case class SimpleEdge[Node](_1: Node, _2: Node) extends EdgeLike[Node]
-  case class LabeledEdge[Label, Node](_1: Node, l: Label, _2: Node) extends EdgeLike[Node]
+  case class LabeledEdge[Label, Node](_1: Node, _2: Node, l: Label) extends EdgeLike[Node]
 
   trait DiGraphLike[Node, Edge <: EdgeLike[Node], G <: DiGraphLike[Node, Edge, G]] {
     // The vertices

--- a/src/main/scala/inox/utils/SCC.scala
+++ b/src/main/scala/inox/utils/SCC.scala
@@ -34,13 +34,15 @@ object SCC {
 
       if (lowLinks(v) == indices(v)) {
         var c : Set[T] = Set.empty
-        var stop = false
-        do {
+        // do-while, Scala 3 style
+        // See https://docs.scala-lang.org/scala3/reference/dropped-features/do-while.html
+        while ({
           val x :: xs = s
           c = c + x
           s = xs
-          stop = x == v
-        } while (!stop)
+          // The line below is the do-while condition
+          x != v
+        }) () // This trailing () is important! If we remove it, it messes with the next statement
 
         components = c :: components
       }

--- a/src/main/scala/inox/utils/SerializationMacro.scala
+++ b/src/main/scala/inox/utils/SerializationMacro.scala
@@ -1,0 +1,203 @@
+/* Copyright 2009-2021 EPFL, Lausanne */
+
+package inox.utils
+
+import java.io.{InputStream, OutputStream}
+import java.nio.charset.StandardCharsets
+import scala.quoted._
+
+/**
+  * Macro for creating Serializer for Inox AST.
+  *
+  * Due to technical limitations, the return type is approximated with a general type projection
+  * as opposed to being a path-dependent type over `inoxSerializer`.
+  */
+inline def inoxClassSerializerMacro[T](inline inoxSerializer: InoxSerializer, inline id: Int): InoxSerializer#Serializer[T] =
+  ${ inoxClassSerializerMacroImpl[T]('inoxSerializer, 'id) }
+
+// This dummy function delegates the actual work to `classSerializerMacroWorkhorse`
+def inoxClassSerializerMacroImpl[T](inoxSerializer: Expr[InoxSerializer], id: Expr[Int])
+                                   (using Quotes, Type[T]): Expr[InoxSerializer#Serializer[T]] = {
+  import quotes.reflect._
+  // Prefixes we would like to substitute by `InoxSerializer.this.trees`
+  // For instance, if we see the type `inox.ast.Expressions.Assume`,
+  // we replace it with `InoxSerializer.this.trees.Assume`.
+  // (see docstring of classSerializerMacroWorkhorse for an actual example)
+  val prefixesToSubst = Set(
+    This(TypeTree.of[inox.ast.Expressions].tpe.typeSymbol).tpe,
+    This(TypeTree.of[inox.ast.Types].tpe.typeSymbol).tpe,
+    This(TypeTree.of[inox.ast.Definitions].tpe.typeSymbol).tpe
+  )
+
+  classSerializerMacroWorkhorse(inoxSerializer, id)(prefixesToSubst)
+}
+
+/**
+  * Generate a `Serializer` for a given `T`.
+  *
+  * For instance, if `T` is inox.ast.Expression.Assume, the following code is generated:
+  *
+  * {{{
+  * // Note that we assume the macro is called within `InoxSerializer` to be able to refer to its `this`.
+  * new InoxSerializer.this.Serializer[InoxSerializer.this.trees.Assume](id) {
+  *    override def write(instance: InoxSerializer.this.trees.Assume, out: OutputStream): Unit = {
+  *      InoxSerializer.this.writeObject(instance.pred, out)
+  *      InoxSerializer.this.writeObject(instance.body, out)
+  *    }
+  *    override def read(in: InputStream): InoxSerializer.this.trees.Assume = {
+  *      val pred = InoxSerializer.this.readObject(in).asInstanceOf[InoxSerializer.this.trees.Expr]
+  *      val body = InoxSerializer.this.readObject(in).asInstanceOf[InoxSerializer.this.trees.Expr]
+  *      new InoxSerializer.this.trees.Assume(pred, body)
+  *    }
+  * }
+  * }}}
+  */
+def classSerializerMacroWorkhorse[T](inoxSerializer: Expr[InoxSerializer], id: Expr[Int])
+                                    (using q: Quotes, t: Type[T])
+                                    (prefixesToSubst: Set[q.reflect.TypeRepr]): Expr[InoxSerializer#Serializer[T]] = {
+  import quotes.reflect._
+
+  // First, get the class symbol of the type for which we would like to generate a Serializer.
+  val (clsSym, tySubstArg) = TypeTree.of[T].tpe match {
+    // e.g. if we have class Foo and T = Foo, we would match this branch
+    case tr: TypeRef => (tr.classSymbol.get, List.empty[(Symbol, TypeRef)])
+    // e.g. if we have class FooBar[A, B] and T = FooBar[Int, String],
+    // then we would match this branch with args = List(Int, String)
+    // We also return the mapping A -> Int, B -> String
+    // (in a form of list List((A, Int), (B, String)) as we need the ordering for latter on).
+    case AppliedType(tr: TypeRef, args) =>
+      val clsSym = tr.classSymbol.get
+      val tyParams = clsSym.primaryConstructor.paramSymss.head.map(_.asInstanceOf[Symbol])
+      (clsSym, tyParams.zip(args))
+    // (case) objects have a special treatment
+    case tr: TermRef if tr.classSymbol.isDefined =>
+      return caseObjectSerializerMacroWorkhorse(inoxSerializer, id)
+    case x =>
+      assert(false, s"Unable to handle type $x")
+  }
+  // We copy tySubstArg into a Map for cases where we are not interested in the ordering of the subst.
+  val tySubstArgMap = tySubstArg.toMap
+
+  // Get all fields that have a corresponding parameter in the primary constructor.
+  // For that, we use paramSymss, which is best explained with an example.
+  // E.g. paramSymss of class Foo[A](f1: Int, f2: Expr)(f3: A) is:
+  //    List(List(type A), List(val f1, val f2), List(val f3))
+  // We don't want the "type A", so we drop the first element of the list if our T is an applied type.
+  // We the previous example, we would get List(List(val f1, val f2), List(val f3)) for ctorFields
+  val ctorFields = clsSym.primaryConstructor.paramSymss
+    .drop(if (tySubstArgMap.isEmpty) 0 else 1)
+    .map(_.map { ctorParamSym =>
+      // Now get the corresponding *field* symbol of the constructor *parameter*.
+      clsSym.memberFields.find(_.name == ctorParamSym.name).get
+    })
+
+  // We are also intersted in the type of these parameters. We need the types for generating the `read` method.
+  // To do so, we get the DefDef tree of the constructor and pick `termParams`.
+  // With the previous example, `termParams` would give us:
+  //    List(List(ValDef(f1, Int), ValDef(f2, inox.ast.Expression.Expr)), List(ValDef(f3, A)))
+  // Here `A` is a type parameter, and need to be substituted by what it was applied to.
+  // For instance, if we have T = Foo[Boolean], then we would like to get the following list:
+  //    List(List(Int, inox.ast.Expression.Expr), List(Boolean))
+  // However, the type inox.ast.Expression.Expr is incorrect; we actually need to have `InoxSerializer.this.trees.Expr`.
+  // For that, we need to also substitute all prefixes `inox.ast.Expression` (as well as `inox.ast.Types` and `inox.ast.Types`)
+  // by `InoxSerializer.this.trees`.
+  // (Because Stainless also needs `classSerializerMacroWorkhorse` and introduces other such prefixes, this method
+  // expects an argument `prefixesToSubst` instead of hardcoding `inox.ast.Expression` & cie).
+
+  // Represents `InoxSerializer.this.trees`.
+  val treesSel = TermRef(inoxSerializer.asTerm.tpe, "trees")
+
+  // Map to substitute types as described above.
+  val treeMap = new TreeMap {
+    override def transformTypeTree(tree: TypeTree)(owner: Symbol): TypeTree = {
+      tySubstArgMap.get(tree.tpe.typeSymbol) match {
+        case Some(t) => Inferred(t)
+        // Note that we match on a TypeRepr, and not a TypeTree, as the TypeTree is just an Inferred wrapping the TypeRepr
+        // Unfortunately, there are no TypeReprMap, so we must do the traversing ourselves...
+        case None => tree.tpe match {
+          case TypeRef(qualifier, designator) if prefixesToSubst.exists(_ =:= qualifier) =>
+            TypeSelect.copy(tree)(Ref.term(treesSel), designator)
+          case AppliedType(tycon, args) =>
+            val tyconRec = transformTypeTree(Inferred(tycon))(owner)
+            val argsRec = transformTypeTrees(args.map(Inferred.apply))(owner)
+            Applied(tyconRec, argsRec)
+          // TODO: There are other TypeRef, but we do not need to currently handle them
+          case _ =>
+            super.transformTypeTree(tree)(owner)
+        }
+      }
+    }
+  }
+
+  // Types of all fields, according to the above description.
+  val ctorFieldsType: List[List[TypeTree]] = clsSym.primaryConstructor.tree.asInstanceOf[DefDef].termParamss
+    .map(_.params.map(valDef =>
+      treeMap.transformTypeTree(valDef.tpt)(valDef.symbol)))
+
+  val generated = '{
+    // For some reason, the compiler is not happy if we try to do new $inoxSerializer.Serializer[T], so we create an alias...
+    val ix = $inoxSerializer
+    val serializer = new ix.Serializer[T]($id) {
+      // Note: the occurences of T will be substitued by the actual type we are fed with.
+      override def write(instance: T, out: OutputStream): Unit = {
+        ${
+          // List of statements that write all (constructor) fields, one by one
+          val stmts = ctorFields.flatten.map { field =>
+            val fieldSelect = Select('{instance}.asTerm, field).asExpr
+            '{$inoxSerializer.writeObject($fieldSelect, out)}
+          }
+          Expr.block(stmts, '{()})
+        }
+      }
+
+      override def read(in: InputStream): T = {
+        ${
+          val valDefs: List[List[ValDef]] = ctorFields.zip(ctorFieldsType).map {
+            case (fields, fieldTyReprs) => fields.zip(fieldTyReprs).map {
+              case (field, fieldTyRepr) => fieldTyRepr.tpe.asType match {
+                case '[fieldTy] =>
+                  val valDefSym = Symbol.newVal(Symbol.noSymbol, field.name, fieldTyRepr.tpe, Flags.EmptyFlags, Symbol.noSymbol)
+                  ValDef(valDefSym, Some('{$inoxSerializer.readObject(in).asInstanceOf[fieldTy]}.asTerm))
+              }
+            }
+          }
+
+          val selectCtor = Select(New(TypeTree.of[T]), clsSym.primaryConstructor)
+          // If the class is parameterized, we first apply it to the args in tySubstArg.
+          val tyAppliedCtor =
+            if (tySubstArg.nonEmpty) selectCtor.appliedToTypes(tySubstArg.map(_._2))
+            else selectCtor
+          val valDefsRefs = valDefs.map(_.map(valDef => Ref(valDef.symbol)))
+          val termAppliedCtor =
+            tyAppliedCtor.appliedToArgss(valDefsRefs)
+
+          Block(valDefs.flatten, termAppliedCtor).asExprOf[T]
+        }
+      }
+    }
+    serializer
+  }
+  // To print the generated code, uncomment the println
+  // println(generated.show)
+  generated
+}
+
+def caseObjectSerializerMacroWorkhorse[T](inoxSerializer: Expr[InoxSerializer], id: Expr[Int])
+                                         (using q: Quotes, t: Type[T]): Expr[InoxSerializer#Serializer[T]] = {
+  import quotes.reflect._
+
+  val generated = '{
+    // For some reason, the compiler is not happy if we try to do new $inoxSerializer.Serializer[T], so we create an alias...
+    val ix = $inoxSerializer
+    val serializer = new ix.Serializer[T]($id) {
+      // Note: the occurences of T will be substitued by the actual type we are fed with.
+      override def write(instance: T, out: OutputStream): Unit = ()
+
+      override def read(in: InputStream): T = ${Ident(TypeTree.of[T].tpe.asInstanceOf[TermRef]).asExprOf[T]}
+    }
+    serializer
+  }
+  // To print the generated code, uncomment the println
+  // println(generated.show)
+  generated
+}

--- a/src/test/scala/inox/TestSilentReporter.scala
+++ b/src/test/scala/inox/TestSilentReporter.scala
@@ -5,20 +5,20 @@ package inox
 class TestSilentReporter extends DefaultReporter(Set()) {
   var lastErrors: List[String] = Nil
 
-  override def emit(msg: Message): Unit = msg match { 
+  override def emit(msg: Message): Unit = msg match {
     case Message(ERROR, _, msg) => lastErrors ++= List(msg.toString)
     case Message(FATAL, _, msg) => lastErrors ++= List(msg.toString)
     case _ =>
   }
 
-  override def debug(pos: utils.Position, msg: => Any)(implicit section: DebugSection): Unit = {
+  override def debug(pos: utils.Position, msg: => Any)(using DebugSection): Unit = {
     //println(msg)
     super.debug(pos, msg)
   }
 }
 
 class TestErrorReporter extends DefaultReporter(Set()) {
-  override def emit(msg: Message): Unit = msg match { 
+  override def emit(msg: Message): Unit = msg match {
     case Message(ERROR | FATAL, _, _) => super.emit(msg)
     case _ =>
   }

--- a/src/test/scala/inox/ast/ExprOpsSuite.scala
+++ b/src/test/scala/inox/ast/ExprOpsSuite.scala
@@ -6,10 +6,10 @@ package ast
 import org.scalatest.funsuite.AnyFunSuite
 
 class ExprOpsSuite extends AnyFunSuite {
-  import inox.trees._
-  import inox.trees.exprOps._
+  import inox.trees.{given, _}
+  import inox.trees.exprOps.{given, _}
 
-  implicit val ctx0 = TestContext.empty
+  given ctx0: Context = TestContext.empty
 
   private def foldConcatNames(e: Expr, subNames: Seq[String]): String = e match {
     case Variable(id, _, _) => subNames.mkString + id.name
@@ -271,9 +271,9 @@ class ExprOpsSuite extends AnyFunSuite {
       val ctx = ctx0
     }
 
-    import program._
-    import program.trees._
-    import program.symbols._
+    import program.{given, _}
+    import program.trees.{given, _}
+    import program.symbols.{given, _}
 
     val types = Seq(BooleanType(),
                     Int32Type(),

--- a/src/test/scala/inox/parsing/ArithmeticParserSuite.scala
+++ b/src/test/scala/inox/parsing/ArithmeticParserSuite.scala
@@ -5,9 +5,9 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class ArithmeticParserSuite extends AnyFunSuite {
 
-  import inox.trees._
-  import interpolator._
-  implicit val symbols = NoSymbols
+  import inox.trees.{given, _}
+  import interpolator.{given, _}
+  given Symbols = NoSymbols
 
   test("Parsing additions.") {
 

--- a/src/test/scala/inox/parsing/BooleanOperationsParserSuite.scala
+++ b/src/test/scala/inox/parsing/BooleanOperationsParserSuite.scala
@@ -5,9 +5,9 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class BooleanOperationsParserSuite extends AnyFunSuite {
 
-  import inox.trees._
-  import interpolator._
-  implicit val symbols = NoSymbols
+  import inox.trees.{given, _}
+  import interpolator.{given, _}
+  given Symbols = NoSymbols
 
   test("Parsing conjunctions.") {
 

--- a/src/test/scala/inox/parsing/ComparisonOperationsParserSuite.scala
+++ b/src/test/scala/inox/parsing/ComparisonOperationsParserSuite.scala
@@ -5,9 +5,9 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class ComparisonOperationsParserSuite extends AnyFunSuite {
 
-  import inox.trees._
-  import interpolator._
-  implicit val symbols = NoSymbols
+  import inox.trees.{given, _}
+  import interpolator.{given, _}
+  given Symbols = NoSymbols
 
   test("Parsing equalities.") {
 

--- a/src/test/scala/inox/parsing/ExprLiteralParserSuite.scala
+++ b/src/test/scala/inox/parsing/ExprLiteralParserSuite.scala
@@ -6,9 +6,9 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class ExprLiteralParserSuite extends AnyFunSuite {
 
-  import inox.trees._
-  import interpolator._
-  implicit val symbols = NoSymbols
+  import inox.trees.{given, _}
+  import interpolator.{given, _}
+  given Symbols = NoSymbols
 
   test("Parsing Boolean literals.") {
 

--- a/src/test/scala/inox/parsing/ExtractorSuite.scala
+++ b/src/test/scala/inox/parsing/ExtractorSuite.scala
@@ -5,9 +5,9 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class ExtractorSuite extends AnyFunSuite {
 
-  import inox.trees._
-  import interpolator._
-  implicit val symbols = NoSymbols
+  import inox.trees.{given, _}
+  import interpolator.{given, _}
+  given Symbols = NoSymbols
 
   test("Extracting entire expression") {
     val es = Seq(

--- a/src/test/scala/inox/parsing/OperationsPrecedenceParserSuite.scala
+++ b/src/test/scala/inox/parsing/OperationsPrecedenceParserSuite.scala
@@ -5,9 +5,9 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class OperationsPrecedenceParserSuite extends AnyFunSuite {
 
-  import inox.trees._
-  import interpolator._
-  implicit val symbols = NoSymbols
+  import inox.trees.{given, _}
+  import interpolator.{given, _}
+  given Symbols = NoSymbols
 
   test("Parsing a mix of boolean, comparison and arithmetic operations.") {
 

--- a/src/test/scala/inox/parsing/QuantifierParserSuite.scala
+++ b/src/test/scala/inox/parsing/QuantifierParserSuite.scala
@@ -5,9 +5,9 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class QuantifierParserSuite extends AnyFunSuite {
 
-  import inox.trees._
-  import interpolator._
-  implicit val symbols = NoSymbols
+  import inox.trees.{given, _}
+  import interpolator.{given, _}
+  given Symbols = NoSymbols
 
   test("Parsing forall.") {
 

--- a/src/test/scala/inox/parsing/TypeParserSuite.scala
+++ b/src/test/scala/inox/parsing/TypeParserSuite.scala
@@ -5,9 +5,9 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class TypeParserSuite extends AnyFunSuite {
 
-  import inox.trees._
-  import interpolator._
-  implicit val symbols = NoSymbols
+  import inox.trees.{given, _}
+  import interpolator.{given, _}
+  given Symbols = NoSymbols
 
   test("Parsing basic types") {
 

--- a/src/test/scala/inox/solvers/SemanticsSuite.scala
+++ b/src/test/scala/inox/solvers/SemanticsSuite.scala
@@ -7,11 +7,11 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.Tag
 
 class SemanticsSuite extends AnyFunSuite {
-  import inox.trees._
-  import inox.trees.dsl._
-  import SolverResponses._
+  import inox.trees.{given, _}
+  import inox.trees.dsl.{given, _}
+  import SolverResponses.{given, _}
 
-  implicit val symbols = NoSymbols
+  given symbols: Symbols = NoSymbols
   val program = InoxProgram(symbols)
 
   val solverNames: Seq[String] = {
@@ -30,11 +30,15 @@ class SemanticsSuite extends AnyFunSuite {
   }
 
   protected def test(name: String, filter: Context => Boolean, tags: Tag*)(body: Context => Unit): Unit = {
+    // Workaround for a compiler crash caused by calling super.test
+    def superTest(self: AnyFunSuite, name: String)(body: => Unit): Unit =
+      self.test(name, tags: _*)(body)
+
     for {
       sname <- solverNames
       ctx = TestContext(Options(Seq(optSelectedSolvers(Set(sname)))))
       if filter(ctx)
-    } super.test(s"$name solver=$sname", tags : _*)(body(ctx))
+    } superTest(this, s"$name solver=$sname")(body(ctx))
   }
 
   protected def filterSolvers(ctx: Context, princess: Boolean = false, cvc4: Boolean = false, unroll: Boolean = false, z3: Boolean = false, native: Boolean = false): Boolean = {

--- a/src/test/scala/inox/solvers/SolverPoolSuite.scala
+++ b/src/test/scala/inox/solvers/SolverPoolSuite.scala
@@ -11,19 +11,18 @@ class SolverPoolSuite extends AnyFunSuite {
   import inox.trees._
   import SolverResponses._
 
-  implicit val ctx = TestContext.empty
+  given ctx: Context = TestContext.empty
   val p = InoxProgram(NoSymbols)
-  val sfactory: SolverFactory { val program: InoxProgram } = {
-    SolverFactory.create(p)("dummy", () => new DummySolver {
-      val program: p.type = p
-      val context = ctx
-    })
-  }
+  val sfactory: SolverFactory { val program: InoxProgram } =
+    SolverFactory.create(p)("dummy", () => new DummySolver(p).asInstanceOf)
 
-  private trait DummySolver extends Solver {
+  private class DummySolver(override val program: InoxProgram,
+                            override val context: Context) extends Solver {
+
+    def this(program: InoxProgram) = this(program, ctx)
+
     val name = "Dummy"
     val description = "dummy"
-    val program: InoxProgram
 
     def declare(vd: ValDef) = ()
     def assertCnstr(e: Expr) = ()

--- a/src/test/scala/inox/solvers/SolversSuite.scala
+++ b/src/test/scala/inox/solvers/SolversSuite.scala
@@ -9,14 +9,14 @@ class SolversSuite extends AnyFunSuite {
   import inox.trees._
   import SolverResponses._
 
-  implicit val ctx = TestContext.empty.copy(options = Options(Seq(
+  given ctx: Context = TestContext.empty.copy(options = Options(Seq(
     optCheckModels(true)
   )))
 
   val p = InoxProgram(NoSymbols)
 
   import p._
-  import p.symbols._
+  import p.symbols.{given, _}
 
   val solverNames: Seq[String] = {
     (if (SolverFactory.hasNativeZ3) Seq("nativez3") else Nil) ++

--- a/src/test/scala/inox/solvers/TimeoutSolverSuite.scala
+++ b/src/test/scala/inox/solvers/TimeoutSolverSuite.scala
@@ -12,20 +12,21 @@ class TimeoutSolverSuite extends AnyFunSuite {
   val ctx = TestContext.empty
   val p = InoxProgram(NoSymbols)
 
-  private class IdioticSolver extends Solver {
+  private class IdioticSolver(override val program: p.type,
+                              override val context: Context) extends Solver {
+    def this() = this(p, ctx)
+
     val name = "Idiotic"
-    val program: p.type = p
-    val context = ctx
 
     var interrupted = false
 
     import SolverResponses._
-    def check(config: CheckConfiguration): config.Response[Model, Assumptions] = {
+    override def check(config: CheckConfiguration): config.Response[Model, Assumptions] = {
       while(!interrupted) Thread.sleep(50L)
       config.cast(Unknown)
     }
 
-    def checkAssumptions(config: Configuration)(assumptions: Set[Expr]): config.Response[Model, Assumptions] = {
+    override def checkAssumptions(config: Configuration)(assumptions: Set[Expr]): config.Response[Model, Assumptions] = {
       while(!interrupted) Thread.sleep(50L)
       config.cast(Unknown)
     }


### PR DESCRIPTION
Note: targets the `scala-3.x` branch.
Notable changes:
* `implicit val` are replaced by the new `given`/`using` feature. It more or less works the same as before, except that `given` instances must be explicitly brought in scope.
    * For instance, in Scala 2, `import symbols._` would also bring the implicit `Symbols` instance in scope. With `given`/`using`, the `given` instance can be brought with `import symbols.given`
* Early-initializer (e.g. `new { val program: p.type = p } extends XYZ`) are replaced by defining local classes overriding the fields in the early-initializer (e.g. `class Impl(override val program: p.type) extends XYZ; new Impl(p)`) 