### PR TITLE
Adding BitVectors literals arithmetic simplification

### DIFF
--- a/src/main/scala/inox/Reporter.scala
+++ b/src/main/scala/inox/Reporter.scala
@@ -166,7 +166,7 @@ class DefaultReporter(debugSections: Set[DebugSection]) extends Reporter(debugSe
 
   def emit(msg: Message) = synchronized {
     println(reline(severityToPrefix(msg.severity), smartPos(msg.position) + msg.msg.toString))
-    printLineContent(msg.position, false)
+    println(lineContent(msg.position, false))
   }
 
   def getLine(pos: Position): Option[String] = {
@@ -185,13 +185,13 @@ class DefaultReporter(debugSections: Set[DebugSection]) extends Reporter(debugSe
 
   val blankPrefix = " " * prefixSize
 
-  def printLineContent(pos: Position, asciiOnly: Boolean): Unit = {
+  def lineContent(pos: Position, asciiOnly: Boolean): String = {
     getLine(pos) match {
       case Some(line) =>
         // Scala positions probably assume 1 tab = 8 spaces, so we replaces tabs
         // for the carret (^) computed below to be aligned
-        println(blankPrefix+line.replace("\t", " " * 8))
-        pos match {
+        val blank = blankPrefix + line.replace("\t", " " * 8) + "\n"
+        blank + (pos match {
           case rp: RangePosition =>
             val bp = rp.focusBegin
             val ep = rp.focusEnd
@@ -205,17 +205,17 @@ class DefaultReporter(debugSections: Set[DebugSection]) extends Reporter(debugSe
             }
 
             if (asciiOnly)
-              println(blankPrefix+(" " * (bp.col - 1) + carret))
+              blankPrefix+(" " * (bp.col - 1) + carret)
             else
-              println(blankPrefix+(" " * (bp.col - 1) + Console.RED+carret+Console.RESET))
+              blankPrefix+(" " * (bp.col - 1) + Console.RED+carret+Console.RESET)
 
           case op: OffsetPosition =>
             if (asciiOnly)
-              println(blankPrefix+(" " * (op.col - 1) + "^"))
+              blankPrefix+(" " * (op.col - 1) + "^")
             else
-              println(blankPrefix+(" " * (op.col - 1) + Console.RED+"^"+Console.RESET))
-        }
-      case None =>
+              blankPrefix+(" " * (op.col - 1) + Console.RED+"^"+Console.RESET)
+        })
+      case None => ""
     }
   }
 
@@ -246,6 +246,6 @@ class PlainTextReporter(debugSections: Set[DebugSection]) extends DefaultReporte
       println(smartPos(msg.position) + "debug: " + msg.msg.toString)
     else
       println(smartPos(msg.position) + msg.msg.toString)
-    printLineContent(msg.position, true)
+    println(lineContent(msg.position, true))
   }
 }

--- a/src/main/scala/inox/ast/Definitions.scala
+++ b/src/main/scala/inox/ast/Definitions.scala
@@ -33,7 +33,7 @@ trait Definitions { self: Trees =>
   case class ADTLookupException(id: Identifier) extends LookupException(id, "adt")
 
   case class NotWellFormedException(d: Definition, info: Option[String] = None)
-    extends Exception(s"Not well formed definition $d" + (info map { i => s" \n\tbecause $i" } getOrElse ""))
+    extends Exception(s"Not well formed definition $d" + (info map { i => s"\n\tbecause $i" } getOrElse ""))
 
   /** Common super-type for [[ValDef]] and [[Expressions.Variable Variable]].
     *


### PR DESCRIPTION
Note: targets the `scala-3.x` branch.
That addition is needed for some tests in `GenC` (with the Dotty frontend) to succeed (more specifically, some arrays require a literal size). The Stainless extraction happens before the constant unfolding in the Dotty pipeline.
The other two minor changes are here to help with negative tests checks (for later on)