### PR TITLE
Fix 'unknown constant k0!xyz' arising in some cases when using smt-z3

### DIFF
--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -113,7 +113,7 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
     // @nv: Z3 uses identifiers of the shape 'k!\d+' to represent
     //      its array functions, so we have to make sure to avoid collisions!
     if (id.name == "k") {
-      super.id2sym(FreshIdentifier("k0"))
+      SSymbol(s"k0!${id.id}")
     } else {
       super.id2sym(id)
     }


### PR DESCRIPTION
The following snippet*:
```scala
object Test {

  sealed trait Term {
    def fun(b: BigInt): Boolean = this match {
      case Var(k) => k == b
    }
  }
  case class Var(k: BigInt) extends Term // Important! No crash occurs if the variable is named other than k


  def patmat(t: Term, b: BigInt): Unit = {
    t match {
      case Var(_) =>
        // Obviously not true, but we are interested in the unfolding of t.fun
        assert(t.fun(b))
        ()
    }
  }
}
```
triggers the following error when using `smt-z3`
```
error: Internal solver error in z3: line 47 column 75: unknown constant k0!0 (Term!2) 
warning:  - Result for 'body assertion' VC for patmat @16:16:
warning: !t.isInstanceOf[Var] || fun(t, b)
Test.scala:16:16: warning:  => UNKNOWN
                   assert(t.fun(b))
```

This tiny PR addresses this small issue.

*Issue found by Andrea Gilot and Noé De Santo with https://github.com/epfl-lara/bolts/blob/c77d1e6598b084fc12d67fbc991f743102dbcef4/system-f/Transformations.scala#L126