### PR TITLE
Make PurityOptions a case class, fix warnings, disable scaladoc gen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,6 +138,7 @@ lazy val root = (project in file("."))
     parallelExecution := false
   )) : _*)
   .settings(compile := ((Compile / compile) dependsOn script).value)
+  .settings(Compile / packageDoc / mappings := Seq())
   .dependsOn(smtlib)
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ libraryDependencies ++= Seq(
 
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
-lazy val smtlib = ghProject("https://github.com/epfl-lara/scala-smtlib.git", "ffb61e571aeb37b741d4bba47f8e56f88d7285b5")
+lazy val smtlib = ghProject("https://github.com/epfl-lara/scala-smtlib.git", "351cad5bc03d59c989f24bc316fdc1d6a722f11c")
 
 lazy val scriptName = settingKey[String]("Name of the generated 'inox' script")
 

--- a/src/main/scala/inox/ast/Definitions.scala
+++ b/src/main/scala/inox/ast/Definitions.scala
@@ -108,7 +108,7 @@ trait Definitions { self: Trees =>
     def fresh(name: String, tpe: Type, alwaysShowUniqueID: Boolean = false) =
       ValDef(FreshIdentifier(name, alwaysShowUniqueID), tpe)
     def apply(id: Identifier, tpe: Type, flags: Seq[Flag] = Seq.empty) = new ValDef(Variable(id, tpe, flags))
-    def unapply(vd: ValDef): Option[(Identifier, Type, Seq[Flag])] = Some((vd.id, vd.tpe, vd.flags))
+    def unapply(vd: ValDef): (Identifier, Type, Seq[Flag]) = (vd.id, vd.tpe, vd.flags)
   }
 
   type Symbols >: Null <: AbstractSymbols

--- a/src/main/scala/inox/ast/Printers.scala
+++ b/src/main/scala/inox/ast/Printers.scala
@@ -85,6 +85,15 @@ trait Printer {
   }
 
   private val dbquote = "\""
+  private val not = "\u00AC"
+  private val neq = "\u2260"
+  private val notIn = "\u2209"
+  private val in = "\u2208"
+  private val subset = "\u2286"
+  private val notSubset = "\u2288"
+  private val union = "\u222A"
+  private val inter = "\u2229"
+  private val forall = "\u2200"
 
   def pp(tree: Tree)(using ctx: PrinterContext): Unit = {
     if (requiresBraces(tree, ctx.parent) && !ctx.parent.contains(tree)) {
@@ -121,7 +130,7 @@ trait Printer {
           |$e"""
 
     case Forall(args, e) =>
-      p"\u2200${nary(args)}. $e"
+      p"$forall${nary(args)}. $e"
 
     case Choose(res, pred) =>
       p"choose(($res) => $pred)"
@@ -140,7 +149,7 @@ trait Printer {
       p"${nary(exprs, "| || ")}"
     } // Ugliness award! The first | is there to shield from stripMargin()
     case Not(Equals(l, r)) => optP {
-      p"$l \u2260 $r"
+      p"$l $neq $r"
     }
     case Implies(l, r) => optP {
       p"$l ==> $r"
@@ -271,24 +280,24 @@ trait Printer {
       } else {
         p"{${rs.toSeq}, * -> $dflt}"
       }
-    case Not(ElementOfSet(e, s)) => p"$e \u2209 $s"
-    case ElementOfSet(e, s) => p"$e \u2208 $s"
-    case SubsetOf(l, r) => p"$l \u2286 $r"
-    case Not(SubsetOf(l, r)) => p"$l \u2288 $r"
-    case SetAdd(s, e) => p"$s \u222A {$e}"
-    case SetUnion(l, r) => p"$l \u222A $r"
-    case BagUnion(l, r) => p"$l \u222A $r"
+    case Not(ElementOfSet(e, s)) => p"$e $notIn $s"
+    case ElementOfSet(e, s) => p"$e $in $s"
+    case SubsetOf(l, r) => p"$l $subset $r"
+    case Not(SubsetOf(l, r)) => p"$l $notSubset $r"
+    case SetAdd(s, e) => p"$s $union {$e}"
+    case SetUnion(l, r) => p"$l $union $r"
+    case BagUnion(l, r) => p"$l $union $r"
     case SetDifference(l, r) => p"$l \\ $r"
     case BagDifference(l, r) => p"$l \\ $r"
-    case SetIntersection(l, r) => p"$l \u2229 $r"
-    case BagIntersection(l, r) => p"$l \u2229 $r"
+    case SetIntersection(l, r) => p"$l $inter $r"
+    case BagIntersection(l, r) => p"$l $inter $r"
     case BagAdd(b, e) => p"$b + $e"
     case MultiplicityInBag(e, b) => p"$b($e)"
     case MapApply(m, k) => p"$m($k)"
     case MapUpdated(m, k, v) => p"$m.updated($k, $v)"
     case MapMerge(mask, m1, m2) => p"$mask.mapMerge($m1, $m2)"
 
-    case Not(expr) => p"\u00AC$expr"
+    case Not(expr) => p"$not$expr"
 
     case vd @ ValDef(id, tpe, flags) =>
       if (flags.isEmpty) {

--- a/src/main/scala/inox/solvers/package.scala
+++ b/src/main/scala/inox/solvers/package.scala
@@ -10,7 +10,7 @@ package object solvers {
 
   object optAssumeChecked extends FlagOptionDef("assume-checked", false)
 
-  class PurityOptions(val assumeChecked: Boolean)
+  case class PurityOptions(assumeChecked: Boolean)
 
   object PurityOptions {
     def apply(ctx: Context) =

--- a/src/main/scala/inox/solvers/z3/Z3Native.scala
+++ b/src/main/scala/inox/solvers/z3/Z3Native.scala
@@ -905,7 +905,7 @@ object Z3Native {
 
   def tryZ3[T](res: => T): Option[T] =
     // @nv: Z3 sometimes throws an exception when functions are called after Z3 has been canceled
-    try { Some(res) } catch { case e: Z3Exception if e.getMessage == "canceled" => None }
+    try { Some(res) } catch { case e: Z3Exception => None }
 
   def tryZ3Opt[T](res: => Option[T]): Option[T] =
     tryZ3(res).flatten

--- a/src/test/scala/inox/ast/ExtractorsSuite.scala
+++ b/src/test/scala/inox/ast/ExtractorsSuite.scala
@@ -12,18 +12,21 @@ class ExtractorsSuite extends AnyFunSuite {
     val e1 = Plus(Int32Literal(1), Int32Literal(1))
     val e2 = e1 match {
       case Operator(es, builder) => builder(es)
+      case _ => fail(s"$e1 did not match Operator extractor")
     }
     assert(e1 === e2)
 
     val e3 = Times(Variable.fresh("x", IntegerType()), IntegerLiteral(1))
     val e4 = e3 match {
       case Operator(es, builder) => builder(es)
+      case _ => fail(s"$e3 did not match Operator extractor")
     }
     assert(e3 === e4)
 
     val e5 = Plus(Int8Literal(1), Int8Literal(1))
     val e6 = e5 match {
       case Operator(es, builder) => builder(es)
+      case _ => fail(s"$e5 did not match Operator extractor")
     }
     assert(e5 === e6)
 
@@ -31,6 +34,7 @@ class ExtractorsSuite extends AnyFunSuite {
     val e7 = Plus(BVLiteral(true, 1, size), BVLiteral(true, 1, size))
     val e8 = e7 match {
       case Operator(es, builder) => builder(es)
+      case _ => fail(s"$e7 did not match Operator extractor")
     }
     assert(e7 === e8)
   }
@@ -39,18 +43,21 @@ class ExtractorsSuite extends AnyFunSuite {
     val e1 = Equals(IntegerLiteral(1), IntegerLiteral(1))
     val e2 = e1 match {
       case Operator(es, builder) => builder(es)
+      case _ => fail(s"$e1 did not match Operator extractor")
     }
     assert(e1 === e2)
 
     val e3 = Equals(BooleanLiteral(true), BooleanLiteral(false))
     val e4 = e3 match {
       case Operator(es, builder) => builder(es)
+      case _ => fail(s"$e3 did not match Operator extractor")
     }
     assert(e3 === e4)
 
     val e5 = TupleSelect(Tuple(Seq(IntegerLiteral(1), IntegerLiteral(2))), 2)
     val e6 = e5 match {
       case Operator(es, builder) => builder(es)
+      case _ => fail(s"$e5 did not match Operator extractor")
     }
     assert(e5 === e6)
   }
@@ -67,19 +74,19 @@ class ExtractorsSuite extends AnyFunSuite {
       Int32Type(),
       IntegerType())
     val a2 = a1 match {
-      case Operator(es, builder) => {
+      case Operator(es, builder) =>
         assert(es === Seq(Int32Literal(0), x, Int32Literal(3), y, Int32Literal(5), z, IntegerLiteral(10)))
         builder(es)
-      }
+      case _ => fail(s"$a1 did not match Operator extractor")
     }
     assert(a2 === a1)
 
     val app1 = MapApply(a1, Int32Literal(0))
     val app2 = app1 match {
-      case Operator(es, builder) => {
+      case Operator(es, builder) =>
         assert(es === Seq(a1, Int32Literal(0)))
         builder(es)
-      }
+      case _ => fail(s"$app1 did not match Operator extractor")
     }
     assert(app1 === app2)
   }


### PR DESCRIPTION
Note: `PurityOptions` is used as a key in some maps, having it as a non-case class leads to unexpected results (due to the nature of `hash` and `==` relying on reference equality instead of structural equality)