### PR TITLE
Fix options parser for empty sequences

### DIFF
--- a/src/main/scala/inox/Options.scala
+++ b/src/main/scala/inox/Options.scala
@@ -124,6 +124,7 @@ object OptionParsers {
 
   def seqParser[A](base: OptionParser[A]): OptionParser[Seq[A]] = s => {
     def traverse[A, B](s: Seq[A], acc: Seq[B])(f: A => Option[B]): Option[Seq[B]] = s match {
+      case Seq() => Some(acc)
       case Seq(a) => f(a).map(acc :+ _)
       case a +: as => f(a) match {
         case Some(b) => traverse(as, acc :+ b)(f)


### PR DESCRIPTION
E.g. if give Stainless the following `stainless.conf`
```
debug = []
```
ensure we do not crash with a `MatchError`.