### PR TITLE
Add signed bit-vectors arithmetic support for the Princess backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,6 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.9" % "test;it",
   "org.apache.commons" % "commons-lang3" % "3.4",
-  ("uuverifiers" %% "princess" % "2020-03-12").cross(CrossVersion.for3Use2_13),
   ("org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2").cross(CrossVersion.for3Use2_13)
 )
 
@@ -59,6 +58,8 @@ lazy val nTestParallelism = {
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
 lazy val smtlib = ghProject("https://github.com/epfl-lara/scala-smtlib.git", "ca9c0226aba1809ae31f7e16dc7d9d0adb48052f")
+
+lazy val princess = ghProject("https://github.com/uuverifiers/princess.git", "ff7b947aff30cd6538c4ded539405d2004c2ed9b")
 
 lazy val scriptName = settingKey[String]("Name of the generated 'inox' script")
 
@@ -150,7 +151,7 @@ lazy val root = (project in file("."))
   )) : _*)
   .settings(compile := ((Compile / compile) dependsOn script).value)
   .settings(Compile / packageDoc / mappings := Seq())
-  .dependsOn(smtlib)
+  .dependsOn(smtlib, princess)
 
 Global / concurrentRestrictions := Seq(
   Tags.limit(Tags.Test, nTestParallelism)

--- a/src/it/scala/inox/solvers/unrolling/BVArithmeticSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/BVArithmeticSuite.scala
@@ -1,0 +1,92 @@
+/* Copyright 2009-2022 EPFL, Lausanne */
+
+package inox
+package solvers
+package unrolling
+
+class BVArithmeticSuite extends SolvingTestSuite {
+  import trees._
+  import dsl._
+
+  import SolverResponses._
+
+  override def configurations = for {
+    solverName  <- Seq("nativez3", "unrollz3", "smt-z3", "smt-cvc4", "princess")
+  } yield Seq(
+    optSelectedSolvers(Set(solverName)),
+    optCheckModels(true)
+  )
+
+  override def optionsString(options: Options): String = {
+    "solvr=" + options.findOptionOrDefault(optSelectedSolvers).head
+  }
+
+  val program = InoxProgram(NoSymbols)
+  object UInt32Type extends BVTypeExtractor(false, 32)
+  val zeroInt32 = BVLiteral(true, 0, 32)
+  val zeroUInt32 = BVLiteral(false, 0, 32)
+
+  test("Signed overflow (addition)") {
+    val x = Variable.fresh("x", Int32Type())
+    val y = Variable.fresh("y", Int32Type())
+    val clause = x > zeroInt32 && y > zeroInt32 && x + y < zeroInt32
+    assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
+  }
+
+  test("Unsigned overflow (addition)") {
+    val x = Variable.fresh("x", UInt32Type())
+    val y = Variable.fresh("y", UInt32Type())
+    val clause = x + y < x
+    assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
+  }
+
+  test("Signed overflow (subtraction)") {
+    val x = Variable.fresh("x", Int32Type())
+    val y = Variable.fresh("y", Int32Type())
+    val clause = x < zeroInt32 && y < zeroInt32 && x - y > zeroInt32
+    assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
+  }
+
+  test("Unsigned overflow (subtraction)") {
+    val x = Variable.fresh("x", UInt32Type())
+    val y = Variable.fresh("y", UInt32Type())
+    val clause = x - y > x
+    assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isSAT)
+  }
+
+  test("Signed associativity") { associativityTest(Int32Type()) }
+
+  test("Unsigned associativity") { associativityTest(UInt32Type()) }
+
+  test("Signed commutativity") { commutativityTest(Int32Type()) }
+
+  test("Unsigned commutativity") { commutativityTest(UInt32Type()) }
+
+  test("Signed distributivity") { distributivityTest(Int32Type()) }
+
+  test("Unsigned distributivity") { distributivityTest(UInt32Type()) }
+
+
+  private def associativityTest(tpe: Type)(using Context): Unit = {
+    val x = Variable.fresh("x", tpe)
+    val y = Variable.fresh("y", tpe)
+    val z = Variable.fresh("z", tpe)
+    val clause: Expr = x + (y + z) !== (x + y) + z
+    assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isUNSAT)
+  }
+
+  private def commutativityTest(tpe: Type)(using Context): Unit = {
+    val x = Variable.fresh("x", tpe)
+    val y = Variable.fresh("y", tpe)
+    val clause: Expr = x + y !== y + x
+    assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isUNSAT)
+  }
+
+  private def distributivityTest(tpe: Type)(using Context): Unit = {
+    val x = Variable.fresh("x", tpe)
+    val y = Variable.fresh("y", tpe)
+    val z = Variable.fresh("z", tpe)
+    val clause: Expr = x * (y + z) !== x * y + x * z
+    assert(SimpleSolverAPI(program.getSolver).solveSAT(clause).isUNSAT)
+  }
+}


### PR DESCRIPTION
The idea is to cast signed BV to unsigned with `Mod.cast2UnsignedBV`, and use the signed BV operators (already done before).