### PR TITLE
Add support for cvc5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,8 @@ lazy val nTestParallelism = {
 
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
-lazy val smtlib = ghProject("https://github.com/epfl-lara/scala-smtlib.git", "ca9c0226aba1809ae31f7e16dc7d9d0adb48052f")
+// lazy val smtlib = RootProject(file("../scala-smtlib")) // If you have a local copy of Scala-SMTLIB and would like to do some changes
+lazy val smtlib = ghProject("https://github.com/epfl-lara/scala-smtlib.git", "51a44878858b427f1a4e5a5eb01d8f796898d812")
 
 // lazy val princess = RootProject(file("../princess")) // If you have a local copy of Princess and would like to do some changes
 lazy val princess = ghProject("https://github.com/uuverifiers/princess.git", "93cbff11d7b02903e532c7b64207bc12f19b79c7")

--- a/src/it/scala/inox/solvers/SolvingTestSuite.scala
+++ b/src/it/scala/inox/solvers/SolvingTestSuite.scala
@@ -6,7 +6,7 @@ package solvers
 trait SolvingTestSuite extends TestSuite {
 
   override def configurations = for {
-    solverName        <- Seq("nativez3", "nativez3-opt", "unrollz3", "princess", "smt-z3", "smt-z3-opt", "smt-cvc4")
+    solverName        <- Seq("nativez3", "nativez3-opt", "unrollz3", "princess", "smt-z3", "smt-z3-opt", "smt-cvc4", "smt-cvc5")
     checkModels       <- Seq(false, true)
     feelingLucky      <- Seq(false, true)
     unrollAssumptions <- Seq(false, true)

--- a/src/it/scala/inox/solvers/unrolling/BVArithmeticSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/BVArithmeticSuite.scala
@@ -11,7 +11,7 @@ class BVArithmeticSuite extends SolvingTestSuite {
   import SolverResponses._
 
   override def configurations = for {
-    solverName  <- Seq("nativez3", "unrollz3", "smt-z3", "smt-cvc4", "princess")
+    solverName  <- Seq("nativez3", "unrollz3", "smt-z3", "smt-cvc4", "smt-cvc5", "princess")
   } yield Seq(
     optSelectedSolvers(Set(solverName)),
     optCheckModels(true)

--- a/src/it/scala/inox/solvers/unrolling/BagSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/BagSuite.scala
@@ -9,7 +9,7 @@ class BagSuite extends SolvingTestSuite with DatastructureUtils {
   import dsl._
 
   override def configurations = for {
-    solverName   <- Seq("nativez3", "unrollz3", "smt-z3", "smt-cvc4")
+    solverName   <- Seq("nativez3", "unrollz3", "smt-z3", "smt-cvc4", "smt-cvc5")
     feelingLucky <- Seq(false, true)
   } yield Seq(
     optSelectedSolvers(Set(solverName)),

--- a/src/it/scala/inox/solvers/unrolling/ChooseSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/ChooseSuite.scala
@@ -9,7 +9,7 @@ class ChooseSuite extends SolvingTestSuite {
   import dsl._
 
   override def configurations =
-    for (nme <- Seq("nativez3", "unrollz3", "smt-z3", "smt-cvc4", "princess")) yield {
+    for (nme <- Seq("nativez3", "unrollz3", "smt-z3", "smt-cvc4", "smt-cvc5", "princess")) yield {
       Seq(optSelectedSolvers(Set(nme)), optCheckModels(true))
     }
 

--- a/src/it/scala/inox/solvers/unrolling/QuantifiersSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/QuantifiersSuite.scala
@@ -18,7 +18,8 @@ class QuantifiersSuite extends TestSuite {
     ("nativez3",     true,  true,  false),
     ("nativez3",     false, false, true ),
     ("princess",     true,  true,  false),
-    ("smt-cvc4",     false, false, true )
+    ("smt-cvc4",     false, false, true ),
+    ("smt-cvc5",     false, false, true ),
   ).map { case (solverName, checkModels, feelingLucky, unrollAssumptions) => Seq(
     optSelectedSolvers(Set(solverName)),
     optCheckModels(checkModels),

--- a/src/it/scala/inox/solvers/unrolling/StringSuite.scala
+++ b/src/it/scala/inox/solvers/unrolling/StringSuite.scala
@@ -11,7 +11,7 @@ class StringSuite extends SolvingTestSuite {
   import SolverResponses._
 
   override def configurations = for {
-    solverName  <- Seq("nativez3", "unrollz3", "smt-z3", "smt-cvc4", "princess")
+    solverName  <- Seq("nativez3", "unrollz3", "smt-z3", "smt-cvc4", "smt-cvc5", "princess")
   } yield Seq(
     optSelectedSolvers(Set(solverName)),
     optCheckModels(true)

--- a/src/main/scala/inox/solvers/smtlib/CVC4Solver.scala
+++ b/src/main/scala/inox/solvers/smtlib/CVC4Solver.scala
@@ -13,33 +13,6 @@ object optCVC4Options extends SetOptionDef[String] {
   val usageRhs = "<cvc4-opt>"
 }
 
-trait CVC4Solver extends SMTLIBSolver with CVC4Target {
-  import context.{given, _}
-  import program.trees._
-  import SolverResponses._
-
-  def interpreterOpts = {
-    Seq(
-      "-q",
-      "--produce-models",
-      "--incremental",
-      // "--dt-rewrite-error-sel", // Removing since it causes CVC4 to segfault on some inputs
-      "--print-success",
-      "--lang", "smt2.5"
-    ) ++ options.findOptionOrDefault(optCVC4Options)
-  }
-
-  override def checkAssumptions(config: Configuration)(assumptions: Set[Expr]) = {
-    push()
-    for (cl <- assumptions) assertCnstr(cl)
-    val res: SolverResponse[Model, Assumptions] = check(Model min config)
-    pop()
-
-    config.cast(res match {
-      case Unsat if config.withUnsatAssumptions =>
-        UnsatWithAssumptions(Set.empty)
-      case _ => res
-    })
-  }
+trait CVC4Solver extends CVCSolver with CVC4Target {
+  override def optCVCOptions: SetOptionDef[String] = optCVC4Options
 }
-

--- a/src/main/scala/inox/solvers/smtlib/CVC5Solver.scala
+++ b/src/main/scala/inox/solvers/smtlib/CVC5Solver.scala
@@ -1,0 +1,18 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package inox
+package solvers
+package smtlib
+
+import inox.OptionParsers._
+
+object optCVC5Options extends SetOptionDef[String] {
+  val name = "solver:cvc5"
+  val default = Set[String]()
+  val elementParser = stringParser
+  val usageRhs = "<cvc5-opt>"
+}
+
+trait CVC5Solver extends CVCSolver with CVC5Target {
+  override def optCVCOptions: SetOptionDef[String] = optCVC5Options
+}

--- a/src/main/scala/inox/solvers/smtlib/CVC5Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/CVC5Target.scala
@@ -10,18 +10,18 @@ import _root_.smtlib.interpreters._
 import _root_.smtlib.theories._
 import _root_.smtlib.theories.cvc._
 
-trait CVC4Target extends CVCTarget {
-  import context.{given, _}
-  import program._
-  import program.trees._
-  import program.symbols.{given, _}
+trait CVC5Target extends CVCTarget {
+  import context.{*, given}
+  import program.*
+  import program.symbols.{*, given}
+  import program.trees.*
 
-  def targetName = "cvc4"
+  def targetName = "cvc5"
 
   override protected val interpreter: ProcessInterpreter = {
     val opts = interpreterOpts
     reporter.debug("Invoking solver with "+opts.mkString(" "))
-    new CVC4Interpreter("cvc4", opts.toArray)
+    new CVC5Interpreter("cvc5", opts.toArray)
   }
-  override val cvcSets: Sets = CVC4Sets
+  override val cvcSets: Sets = CVC5Sets
 }

--- a/src/main/scala/inox/solvers/smtlib/CVCSolver.scala
+++ b/src/main/scala/inox/solvers/smtlib/CVCSolver.scala
@@ -1,0 +1,39 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package inox
+package solvers
+package smtlib
+
+import inox.OptionParsers._
+
+trait CVCSolver extends SMTLIBSolver with CVCTarget {
+  import context.{given, _}
+  import program.trees._
+  import SolverResponses._
+
+  def optCVCOptions: SetOptionDef[String]
+
+  def interpreterOpts = {
+    Seq(
+      "-q", // quiet
+      "--produce-models", // support the get-value and get-model commands
+      "--incremental",
+      "--print-success",
+      "--lang", "smt2.6"
+    ) ++ options.findOptionOrDefault(optCVCOptions)
+  }
+
+  override def checkAssumptions(config: Configuration)(assumptions: Set[Expr]) = {
+    push()
+    for (cl <- assumptions) assertCnstr(cl)
+    val res: SolverResponse[Model, Assumptions] = check(Model min config)
+    pop()
+
+    config.cast(res match {
+      case Unsat if config.withUnsatAssumptions =>
+        UnsatWithAssumptions(Set.empty)
+      case _ => res
+    })
+  }
+}
+

--- a/src/main/scala/inox/solvers/smtlib/CVCTarget.scala
+++ b/src/main/scala/inox/solvers/smtlib/CVCTarget.scala
@@ -1,0 +1,151 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package inox
+package solvers
+package smtlib
+
+import _root_.smtlib.trees.Terms.{Identifier => SMTIdentifier, _}
+import _root_.smtlib.trees.Commands._
+import _root_.smtlib.theories._
+import _root_.smtlib.theories.cvc._
+
+trait CVCTarget extends SMTLIBTarget with SMTLIBDebugger {
+  import context.{given, _}
+  import program._
+  import program.trees._
+  import program.symbols.{given, _}
+
+  val cvcSets: Sets
+  import cvcSets._
+
+  override protected def computeSort(t: Type): Sort = t match {
+    case SetType(base) => SetSort(declareSort(base))
+    case _ => super.computeSort(t)
+  }
+
+  override protected def fromSMT(t: Term, otpe: Option[Type] = None)(using Context): Expr = {
+    (t, otpe) match {
+      // EK: This hack is necessary for sygus which does not strictly follow smt-lib for negative literals
+      case (SimpleSymbol(SSymbol(v)), Some(IntegerType())) if v.startsWith("-") =>
+        try {
+          IntegerLiteral(v.toInt)
+        } catch {
+          case _: Throwable => super.fromSMT(t, otpe)
+        }
+
+      // XXX @nv: CVC4 seems to return some weird representations for certain adt selectors
+      case (FunctionApplication(SimpleSymbol(s), Seq(e)), _)
+      if s.name.endsWith("'") && selectors.containsB(SSymbol(s.name.init)) =>
+        fromSMT(FunctionApplication(SimpleSymbol(SSymbol(s.name.init)), Seq(e)), otpe)
+
+      // XXX @nv: CVC4 seems to return some weird representations for certain adt constructors
+      case (FunctionApplication(SimpleSymbol(s), args), _)
+      if s.name.endsWith("'") && constructors.containsB(SSymbol(s.name.init)) =>
+        fromSMT(FunctionApplication(SimpleSymbol(SSymbol(s.name.init)), args), otpe)
+
+      // XXX @nv: CVC4 seems to return bv literals instead of booleans sometimes
+      case (FixedSizeBitVectors.BitVectorLit(bs), Some(BooleanType())) if bs.size == 1 =>
+        BooleanLiteral(bs.head)
+      case (FixedSizeBitVectors.BitVectorConstant(n, size), Some(BooleanType())) if size == 1 =>
+        BooleanLiteral(n == 1)
+      case (Core.Equals(e1, e2), _) =>
+        fromSMTUnifyType(e1, e2, None)(Equals.apply) match {
+          case Equals(IsTyped(lhs, BooleanType()), IsTyped(_, BVType(true, 1))) =>
+            Equals(lhs, fromSMT(e2, BooleanType()))
+          case Equals(IsTyped(_, BVType(true, 1)), IsTyped(rhs, BooleanType())) =>
+            Equals(fromSMT(e1, BooleanType()), rhs)
+          case expr => expr
+        }
+      case (EmptySet(sort), Some(SetType(base))) => FiniteSet(Seq.empty, base)
+      case (EmptySet(sort), _) => FiniteSet(Seq.empty, fromSMT(sort))
+
+      case (Singleton(e), Some(SetType(base))) => FiniteSet(Seq(fromSMT(e, base)), base)
+      case (Singleton(e), _) =>
+        val elem = fromSMT(e)
+        FiniteSet(Seq(elem), elem.getType)
+
+      case (Insert(set, es@_*), Some(SetType(base))) => es.foldLeft(fromSMT(set, SetType(base))) {
+        case (FiniteSet(elems, base), e) =>
+          val elem = fromSMT(e, base)
+          FiniteSet(elems.filter(_ != elem) :+ elem, base)
+        case (s, e) => SetAdd(s, fromSMT(e, base))
+      }
+
+      case (Insert(set, es@_*), _) => es.foldLeft(fromSMT(set)) {
+        case (FiniteSet(elems, base), e) =>
+          val elem = fromSMT(e, base)
+          FiniteSet(elems.filter(_ != elem) :+ elem, base)
+        case (s, e) => SetAdd(s, fromSMT(e))
+      }
+
+      case (Union(e1, e2), Some(SetType(base))) =>
+        (fromSMT(e1, SetType(base)), fromSMT(e2, SetType(base))) match {
+          case (FiniteSet(elems1, _), FiniteSet(elems2, _)) => FiniteSet(elems1 ++ elems2, base)
+          case (s1, s2) => SetUnion(s1, s2)
+        }
+
+      case (Union(e1, e2), _) =>
+        (fromSMT(e1), fromSMT(e2)) match {
+          case (fs1@FiniteSet(elems1, b1), fs2@FiniteSet(elems2, b2)) =>
+            val tpe = leastUpperBound(b1, b2)
+            if (tpe == Untyped) unsupported(SetUnion(fs1, fs2), "woot? incompatible set base-types")
+            FiniteSet(elems1 ++ elems2, tpe)
+          case (s1, s2) => SetUnion(s1, s2)
+        }
+
+      case (ArraysEx.Store(e1, e2, e3), Some(MapType(from, to))) =>
+        (fromSMT(e1, MapType(from, to)), fromSMT(e2, from), fromSMT(e3, to)) match {
+          case (FiniteMap(elems, default, _, _), key, value) => FiniteMap(elems :+ (key -> value), default, from, to)
+          case _ => super.fromSMT(t, otpe)
+        }
+
+      case (ArraysEx.Store(e1, e2, e3), _) =>
+        (fromSMT(e1), fromSMT(e2), fromSMT(e3)) match {
+          case (FiniteMap(elems, default, from, to), key, value) => FiniteMap(elems :+ (key -> value), default, from, to)
+          case _ => super.fromSMT(t, otpe)
+        }
+
+      case (FunctionApplication(SimpleSymbol(SSymbol("__array_store_all__")), Seq(_, elem)), Some(MapType(k, v))) =>
+        FiniteMap(Seq(), fromSMT(elem, v), k, v)
+
+      case _ => super.fromSMT(t, otpe)
+    }
+  }
+
+  override protected def toSMT(e: Expr)(using bindings: Map[Identifier, Term]) = e match {
+    case fs@FiniteSet(elems, _) =>
+      if (elems.isEmpty) {
+        EmptySet(declareSort(fs.getType))
+      } else {
+        val selems = elems.map(toSMT)
+
+        if (exprOps.variablesOf(elems.head).isEmpty) {
+          val sgt = Singleton(selems.head)
+
+          if (selems.size > 1) {
+            Insert(selems.tail :+ sgt)
+          } else {
+            sgt
+          }
+        } else {
+          val sgt = EmptySet(declareSort(fs.getType))
+          Insert(selems :+ sgt)
+        }
+      }
+    case SubsetOf(ss, s) => Subset(toSMT(ss), toSMT(s))
+    case ElementOfSet(e, s) => Member(toSMT(e), toSMT(s))
+    case SetDifference(a, b) => Setminus(toSMT(a), toSMT(b))
+    case SetUnion(a, b) => Union(toSMT(a), toSMT(b))
+    case SetAdd(a, b) => Insert(toSMT(b), toSMT(a))
+    case SetIntersection(a, b) => Intersection(toSMT(a), toSMT(b))
+
+    case FiniteMap(_, default, _, _) if !isValue(default) || exprOps.exists {
+      case _: Lambda => true
+      case _ => false
+    } (default) =>
+      unsupported(e, "Cannot encode map with non-constant default value")
+
+    case _ =>
+      super.toSMT(e)
+  }
+}

--- a/src/main/scala/inox/solvers/smtlib/SMTLIBParser.scala
+++ b/src/main/scala/inox/solvers/smtlib/SMTLIBParser.scala
@@ -10,7 +10,6 @@ import _root_.smtlib.lexer.{Tokens => LT, _}
 import _root_.smtlib.trees.Commands.{FunDef => SMTFunDef, _}
 import _root_.smtlib.trees.Terms.{Let => SMTLet, Forall => SMTForall, Identifier => SMTIdentifier, _}
 import _root_.smtlib.theories._
-import _root_.smtlib.theories.experimental._
 import _root_.smtlib.extensions.tip.Terms.{Lambda => SMTLambda, Application => SMTApplication, _}
 import _root_.smtlib.extensions.tip.Commands._
 

--- a/src/main/scala/inox/solvers/smtlib/SMTLIBTarget.scala
+++ b/src/main/scala/inox/solvers/smtlib/SMTLIBTarget.scala
@@ -21,7 +21,6 @@ import _root_.smtlib.trees.Terms.{
 }
 import _root_.smtlib.trees.CommandsResponses._
 import _root_.smtlib.theories.{Constructors => SmtLibConstructors, _}
-import _root_.smtlib.theories.experimental._
 import _root_.smtlib.Interpreter
 
 import scala.collection.BitSet

--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -15,7 +15,6 @@ import _root_.smtlib.interpreters.Z3Interpreter
 import _root_.smtlib.theories.Core.{Equals => SMTEquals, _}
 import _root_.smtlib.theories.Operations._
 import _root_.smtlib.theories._
-import _root_.smtlib.theories.experimental._
 
 import utils._
 

--- a/src/main/scala/inox/solvers/theories/package.scala
+++ b/src/main/scala/inox/solvers/theories/package.scala
@@ -16,8 +16,8 @@ package object theories {
     val targetProgram: Program { val trees: p.trees.type }
   } = ASCIIStringEncoder(p)
 
-  def CVC4(enc: ProgramTransformer)
-          (ev: DeterministicEvaluator { val program: enc.sourceProgram.type }): ProgramTransformer {
+  def CVC(enc: ProgramTransformer)
+         (ev: DeterministicEvaluator { val program: enc.sourceProgram.type }): ProgramTransformer {
     val sourceProgram: enc.targetProgram.type
     val targetProgram: Program { val trees: enc.targetProgram.trees.type }
   } = {

--- a/src/main/scala/inox/tip/Parser.scala
+++ b/src/main/scala/inox/tip/Parser.scala
@@ -9,7 +9,7 @@ import smtlib.lexer.{Tokens => LT, _}
 import smtlib.trees.Commands.{FunDef => SMTFunDef, _}
 import smtlib.trees.Terms.{Let => SMTLet, Forall => SMTForall, Identifier => SMTIdentifier, _}
 import smtlib.theories._
-import smtlib.theories.experimental._
+import smtlib.theories.cvc.{CVC4Sets => Sets} // We use the Set operations as used in CVC4
 import smtlib.extensions.tip.Terms.{Lambda => SMTLambda, Application => SMTApplication, _}
 import smtlib.extensions.tip.Commands._
 

--- a/src/main/scala/inox/tip/Printer.scala
+++ b/src/main/scala/inox/tip/Printer.scala
@@ -6,7 +6,7 @@ package tip
 import smtlib.trees.Terms.{Forall => SMTForall, Identifier => SMTIdentifier, _}
 import smtlib.trees.Commands.{Constructor => SMTConstructor, FunDef => SMTFunDef, _}
 import smtlib.theories._
-import smtlib.theories.experimental._
+import smtlib.theories.cvc.{CVC4Sets => Sets} // We use the Set operations as used in CVC4
 import smtlib.extensions.tip.Terms.{Application => SMTApplication, Lambda => SMTLambda, _}
 import smtlib.extensions.tip.Commands._
 import smtlib.Interpreter

--- a/src/test/scala/inox/solvers/SolversSuite.scala
+++ b/src/test/scala/inox/solvers/SolversSuite.scala
@@ -21,7 +21,8 @@ class SolversSuite extends AnyFunSuite {
   val solverNames: Seq[String] = {
     (if (SolverFactory.hasNativeZ3) Seq("nativez3") else Nil) ++
     (if (SolverFactory.hasZ3)       Seq("smt-z3") else Nil) ++
-    (if (SolverFactory.hasCVC4)     Seq("smt-cvc4") else Nil)
+    (if (SolverFactory.hasCVC4)     Seq("smt-cvc4") else Nil) ++
+    (if (SolverFactory.hasCVC5)     Seq("smt-cvc5") else Nil)
   }
 
   val types = Seq(


### PR DESCRIPTION
cvc5 can be selected with `--solvers=smt-cvc5`, provided that its executable (named `cvc5`) is found in `PATH`.