### PR TITLE
Improve performance of DiGraph

### DIFF
--- a/src/it/scala/inox/TestSuite.scala
+++ b/src/it/scala/inox/TestSuite.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.{CancelAfterFailure, Tag, exceptions}
 import utils._
 
-trait TestSuite extends AnyFunSuite with Matchers with TimeLimits with CancelAfterFailure {
+trait TestSuite extends AnyFunSuite with Matchers with TimeLimits {
 
   protected def configurations: Seq[Seq[OptionValue[_]]] = Seq(Seq.empty)
 

--- a/src/test/scala/inox/utils/GraphsSuite.scala
+++ b/src/test/scala/inox/utils/GraphsSuite.scala
@@ -24,7 +24,7 @@ class GraphsSuite extends AnyFunSuite {
   }
 
   def g1 = {
-    var g = new DiGraph[Node, SimpleEdge[Node]]()
+    var g = DiGraph[Node, SimpleEdge[Node]]()
 
     g ++= Set(A, B, C, D)
 
@@ -44,7 +44,7 @@ class GraphsSuite extends AnyFunSuite {
   }
 
   def g2 = {
-    var g = new DiGraph[Node, SimpleEdge[Node]]()
+    var g = DiGraph[Node, SimpleEdge[Node]]()
 
     g ++= Set(A, B, C, D)
 
@@ -60,7 +60,7 @@ class GraphsSuite extends AnyFunSuite {
   }
 
   def g3 = {
-    var g = new DiGraph[Node, SimpleEdge[Node]]()
+    var g = DiGraph[Node, SimpleEdge[Node]]()
 
     g ++= Set(A, B, C, D, E, F, G, H)
 
@@ -87,7 +87,7 @@ class GraphsSuite extends AnyFunSuite {
   }
 
   def g4 = {
-    var g = new DiGraph[Node, SimpleEdge[Node]]()
+    var g = DiGraph[Node, SimpleEdge[Node]]()
 
     g ++= Set(A, B, C, D, E, F, G, H)
 
@@ -112,7 +112,7 @@ class GraphsSuite extends AnyFunSuite {
   }
 
   def g5 = {
-    var g = new DiGraph[Node, SimpleEdge[Node]]()
+    var g = DiGraph[Node, SimpleEdge[Node]]()
 
     g ++= Set(A, B, C, D, E, F, G, H)
 


### PR DESCRIPTION
Copied/pasted comment from `Graphs.scala`:
Implementation note: `inEdgesMap` and `outEdgesMap` can be derived from `N` and `E`.
However, since `inEdges` and `outEdges` are often used with updated copies of the graph, it is interesting performance-wise to have these maps as fields and "update" them alongside "update" operation such as `+`, `++` etc.