### PR TITLE
Bump to 3.3.3 (does not compile)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ git.useGitDescribe := true
 
 organization := "ch.epfl.lara"
 
-scalaVersion := "3.3.0"
+scalaVersion := "3.3.3"
 
 scalacOptions ++= Seq(
   "-deprecation",


### PR DESCRIPTION
This PR is to discuss about the bump to Scala 3.3.3.

Bumping to this version makes the solver hierarchy for `NativeZ3Opt` not valid anymore, with this error message:

``` 
[error] -- Error: /Users/samuel/EPFL/inox/src/main/scala/inox/solvers/SolverFactory.scala:207:14 
[error] 207 |        class NativeZ3OptImpl(override val program: p.type)
[error]     |              ^
[error]     |parent trait NativeZ3Optimizer has a super call which binds to the value inox.solvers.unrolling.AbstractUnrollingSolver.targetProgram. Super calls can only target methods.
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
```

For now, I found this commit which introduces this check https://github.com/scala/scala3/commit/a53b1855f793d59b0e43925697eb769ebbacba4c.

This was introduced in release 3.3.1.