### PR TITLE
Bump to Scala 3.3.3 with small fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ git.useGitDescribe := true
 
 organization := "ch.epfl.lara"
 
-scalaVersion := "3.3.0"
+scalaVersion := "3.3.3"
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.3
+sbt.version=1.10.0

--- a/src/main/scala/inox/solvers/z3/NativeZ3Optimizer.scala
+++ b/src/main/scala/inox/solvers/z3/NativeZ3Optimizer.scala
@@ -18,7 +18,9 @@ trait NativeZ3Optimizer extends Z3Unrolling with AbstractUnrollingOptimizer  { s
 
   override protected val underlying = NativeZ3Solver.synchronized(new Underlying(targetProgram, context)(using targetSemantics))
 
-  private class Underlying(override val program: targetProgram.type,
+  private type Target = targetProgram.type
+
+  private class Underlying(override val program: Target,
                            override val context: Context)
                           (using override val semantics: targetSemantics.type)
     extends AbstractOptimizer with Z3Native {


### PR DESCRIPTION
Bump Inox to Scala 3.3.3 LTS and sbt to 1.10.0.

On bumping the version, there is a compilation error during type checking (see #210 for details). In short, it boils down to the following declaration:

https://github.com/epfl-lara/inox/blob/9fdb4d494133595fd832584e8aaa64b3f027fbab/src/main/scala/inox/solvers/z3/NativeZ3Optimizer.scala#L21-L23

where the reference to `targetProgram.type` raises the error:

```scala
[error] -- Error: <working_dir>/src/main/scala/inox/solvers/SolverFactory.scala:207:14 
[error] 207 |        class NativeZ3OptImpl(override val program: p.type)
[error]     |              ^
[error]     |parent trait NativeZ3Optimizer has a super call which binds to the value inox.solvers.unrolling.AbstractUnrollingSolver.targetProgram. Super calls can only target methods.
[error] one error found
```

Weirdly, the error is simply fixed by adding an alias:

https://github.com/sankalpgambhir/inox/blob/9144039a31d401653af09671e4a58538acf51cbc/src/main/scala/inox/solvers/z3/NativeZ3Optimizer.scala#L21-L25

```scala
  private type Target = targetProgram.type

  private class Underlying(override val program: Target,
                           override val context: Context)
                          (using override val semantics: targetSemantics.type)
```

This clearly should not change the semantics, so either the fix or the original error triggers a compilation bug. I'm working to minimize it, but it does not seem simple.

I'm not sure if it's best to stay on 3.3.0 or accept this fix for now; opinions are welcome.