### PR TITLE
Add option to ignore models during solving

### DIFF
--- a/src/it/scala/inox/solvers/SolvingTestSuite.scala
+++ b/src/it/scala/inox/solvers/SolvingTestSuite.scala
@@ -15,6 +15,7 @@ trait SolvingTestSuite extends TestSuite {
   } yield Seq(
     optSelectedSolvers(Set(solverName)),
     optCheckModels(checkModels),
+    optIgnoreModels(false),
     optAssumeChecked(assumeChecked),
     unrolling.optFeelingLucky(feelingLucky),
     unrolling.optUnrollAssumptions(unrollAssumptions),

--- a/src/main/scala/inox/Main.scala
+++ b/src/main/scala/inox/Main.scala
@@ -95,6 +95,7 @@ trait MainHelpers {
     solvers.optAssumeChecked -> Description(Solvers, "Assume that all impure expression have been checked"),
     solvers.optNoSimplifications -> Description(Solvers, "Disable selector/quantifier simplifications in solvers"),
     solvers.optCheckModels -> Description(Solvers, "Double-check counter-examples with evaluator"),
+    solvers.optIgnoreModels -> Description(Solvers, s"Do not request models from solvers.\nOverrides and disables ${optCheckModels.name} and ${unrolling.optFeelingLucky.name}."),
     solvers.optSilentErrors -> Description(Solvers, "Fail silently into UNKNOWN when encountering an error"),
     solvers.unrolling.optUnrollBound -> Description(Solvers, "Maximum number of unroll steps to perform"),
     solvers.unrolling.optUnrollFactor -> Description(Solvers, "Number of unrollings to perform between each interaction with the SMT solver"),

--- a/src/main/scala/inox/solvers/Solver.scala
+++ b/src/main/scala/inox/solvers/Solver.scala
@@ -6,6 +6,7 @@ package solvers
 import utils._
 
 object optCheckModels  extends FlagOptionDef("check-models", false)
+object optIgnoreModels extends FlagOptionDef("ignore-models", false)
 object optSilentErrors extends FlagOptionDef("silent-errors", false)
 
 case object DebugSectionSolver extends DebugSection("solver")


### PR DESCRIPTION
Adding option `--ignore-models`, and relevant support for it in the unrolling solver.

Description (through Stainless):

```console
--ignore-models[=true|false]          Do not request models from solvers. (default: false)
                                      Overrides and disables check-models and feeling-lucky.
```

As expected, models cannot be checked if we do not ask the solver for them in the first place. Since `feeling-lucky` also uses models during the proof-checking phase in unrolling, it is also explicitly bypassed. The same models are also used for guiding further unrolling by discovering paths to prioritize, and thus this guidance is also bypassed here while the option is turned on.

With the option on, counterexamples are replaced by `(Empty Model)`. Example on a bolts example changed to be broken:

```scala
[info] [Warning ] /tmp/bolts/algorithms/sorting/QuickSortListOfBigInt.scala:31:21:  => INVALID
[info]                  case Nil() => Nil[BigInt]()
[info]                                ^^^^^^^^^^^^^
[info] [Warning ] Found counter-example:
[info] [Warning ]   (Empty model)
```

Functionality should be complete now. I have noticed no change to a slight improvement on smaller examples from `bolts/algorithms`, and I am continuing to do a more comprehensive check.

I am trying to see what would be reasonable tests to have for this option. Will request merging after that.

Feel free to check and comment on this!