### PR TITLE
Print a finite set {a,b,c} as Set(a,b,c) and a bag as Bag(a,b,c)

### DIFF
--- a/src/main/scala/inox/ast/Printers.scala
+++ b/src/main/scala/inox/ast/Printers.scala
@@ -275,8 +275,8 @@ trait Printer {
     case BVUnsignedToSigned(e) => p"$e.toSigned"
     case BVSignedToUnsigned(e) => p"$e.toUnsigned"
 
-    case fs @ FiniteSet(rs, _) => p"{${rs}}"
-    case fs @ FiniteBag(rs, _) => p"{${rs.toSeq}}"
+    case fs @ FiniteSet(rs, _) => p"Set(${rs})"
+    case fs @ FiniteBag(rs, _) => p"Bag(${rs.toSeq})"
     case fm @ FiniteMap(rs, dflt, _, _) =>
       if (rs.isEmpty) {
         p"{* -> $dflt}"


### PR DESCRIPTION
This change in pretty printer is is visible in e.g. counterexample reporting (not even tested in Inox tests?)