### PR TITLE
Fix cross-version conflict errors in the "docs" subproject.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,8 @@ git.useGitDescribe := true
 
 organization := "ch.epfl.lara"
 
-scalaVersion := "3.5.2"
+val inoxScalaVersion = "3.5.2"
+scalaVersion := inoxScalaVersion
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -132,7 +133,8 @@ lazy val docs = project
     mdocIn  := file("src/main/doc"),
     mdocOut := file("doc"),
     mdocExtraArguments := Seq("--no-link-hygiene"),
-    scalaVersion := "3.0.2",
+    scalaVersion := inoxScalaVersion,
+    excludeDependencies := Seq("org.scala-lang.modules" % "scala-parser-combinators_2.13"),
   )
   .enablePlugins(MdocPlugin)
 

--- a/doc/interpolations.md
+++ b/doc/interpolations.md
@@ -61,7 +61,7 @@ It is also possible to embed types and expressions:
 ```scala
 e"let x: $tpe = $expr in !x"
 // res0: Expr = val x: Boolean = 1 + 1 == 2
-// ¬x
+// !x
 ```
 
 <a name="syntax"></a>
@@ -192,9 +192,9 @@ e"lambda x. x * 0.5"
 
 ```scala
 e"forall x: Int. x > 0"
-// res16: Expr = ∀x: Int. (x > 0)
+// res16: Expr = forall((x: Int) => (x > 0))
 e"∀x. x || true"
-// res17: Expr = ∀x: Boolean. (x || true)
+// res17: Expr = forall((x: Boolean) => (x || true))
 ```
 
 <a name="existential-quantifiers"></a>
@@ -202,9 +202,9 @@ e"∀x. x || true"
 
 ```scala
 e"exists x: BigInt. x < 0"
-// res18: Expr = ¬∀x: BigInt. ¬(x < 0)
+// res18: Expr = !forall((x: BigInt) => !(x < 0))
 e"∃x, y. x + y == 0"
-// res19: Expr = ¬∀x: BigInt, y: BigInt. (x + y ≠ 0)
+// res19: Expr = !forall((x: BigInt, y: BigInt) => (x + y != 0))
 ```
 
 <a name="choose"></a>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.6.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 


### PR DESCRIPTION
# Goals
This PR addresses two issues:
- The project cannot be successfully imported in Intellij IDEA with the Scala plugin.
- The sbt command `docs/mdoc` does not run successfully.

Both currently fail with the error:
```
[error] Modules were resolved with conflicting cross-version suffixes in ProjectRef(uri("file:/home/iswoqqe/git/inox/"), "docs"):
[error]    org.scala-lang.modules:scala-parser-combinators _3, _2.13
```

# Changes
- The 2.13 version of the parser combinators dependency is now excluded in the "docs" subproject.
	- This makes it possible to import the project, but `docs/mdoc` still fails with a few different errors, which is why the changes below also are applied.
- Scala version of the "docs" subproject is increased to 3.5.2 (same as root project).
- The mdoc plugin version is increased to 2.6.3 (latest version).
