### PR TITLE
Change license in `build.sbt` to match repository

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,7 +178,7 @@ addArtifact(ItTest / packageBin / artifact, ItTest / packageBin)
 
 pomIncludeRepository := { _ => false }
 
-licenses := Seq("GNU Affero General Public License, Version 3" -> url("http://www.gnu.org/licenses/agpl-3.0.html"))
+licenses := Seq("Apache License 2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))
 
 homepage := Some(url("https://github.com/epfl-lara/inox"))
 


### PR DESCRIPTION
License full name and link from https://spdx.org/licenses/Apache-2.0.html