### PR TITLE
Extended array theories support for Princess and Eldarica

### DIFF
--- a/src/main/scala/inox/solvers/smtlib/CVC4Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/CVC4Target.scala
@@ -20,7 +20,7 @@ trait CVC4Target extends CVCTarget {
 
   override protected val interpreter: ProcessInterpreter = {
     val opts = interpreterOpts
-    reporter.debug("Invoking solver with "+opts.mkString(" "))
+    reporter.debug("Invoking solver with " + opts.mkString(" "))
     new CVC4Interpreter("cvc4", opts.toArray)
   }
 
@@ -28,6 +28,5 @@ trait CVC4Target extends CVCTarget {
   // So we emit (set-logic all) by default
   emit(SetLogic(ALL()))
 
-
-  override val cvcSets: Sets = CVC4Sets
+  val setTarget: Sets = CVC4Sets
 }

--- a/src/main/scala/inox/solvers/smtlib/CVC5Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/CVC5Target.scala
@@ -20,7 +20,7 @@ trait CVC5Target extends CVCTarget {
 
   override protected val interpreter: ProcessInterpreter = {
     val opts = interpreterOpts
-    reporter.debug("Invoking solver with "+opts.mkString(" "))
+    reporter.debug("Invoking solver with " + opts.mkString(" "))
     new CVC5Interpreter("cvc5", opts.toArray)
   }
 
@@ -28,5 +28,5 @@ trait CVC5Target extends CVCTarget {
   // So we emit (set-logic all) by default
   emit(SetLogic(ALL()))
 
-  override val cvcSets: Sets = CVC5Sets
+  val setTarget: Sets = CVC5Sets
 }

--- a/src/main/scala/inox/solvers/smtlib/CVCTarget.scala
+++ b/src/main/scala/inox/solvers/smtlib/CVCTarget.scala
@@ -9,19 +9,11 @@ import _root_.smtlib.trees.Commands._
 import _root_.smtlib.theories._
 import _root_.smtlib.theories.cvc._
 
-trait CVCTarget extends SMTLIBTarget with SMTLIBDebugger {
+trait CVCTarget extends SMTLIBTarget with SMTSets with SMTLIBDebugger {
   import context.{given, _}
   import program._
   import program.trees._
   import program.symbols.{given, _}
-
-  val cvcSets: Sets
-  import cvcSets._
-
-  override protected def computeSort(t: Type): Sort = t match {
-    case SetType(base) => SetSort(declareSort(base))
-    case _ => super.computeSort(t)
-  }
 
   override protected def fromSMT(t: Term, otpe: Option[Type] = None)(using Context): Expr = {
     (t, otpe) match {
@@ -56,42 +48,6 @@ trait CVCTarget extends SMTLIBTarget with SMTLIBDebugger {
             Equals(fromSMT(e1, BooleanType()), rhs)
           case expr => expr
         }
-      case (EmptySet(sort), Some(SetType(base))) => FiniteSet(Seq.empty, base)
-      case (EmptySet(sort), _) => FiniteSet(Seq.empty, fromSMT(sort))
-
-      case (Singleton(e), Some(SetType(base))) => FiniteSet(Seq(fromSMT(e, base)), base)
-      case (Singleton(e), _) =>
-        val elem = fromSMT(e)
-        FiniteSet(Seq(elem), elem.getType)
-
-      case (Insert(set, es@_*), Some(SetType(base))) => es.foldLeft(fromSMT(set, SetType(base))) {
-        case (FiniteSet(elems, base), e) =>
-          val elem = fromSMT(e, base)
-          FiniteSet(elems.filter(_ != elem) :+ elem, base)
-        case (s, e) => SetAdd(s, fromSMT(e, base))
-      }
-
-      case (Insert(set, es@_*), _) => es.foldLeft(fromSMT(set)) {
-        case (FiniteSet(elems, base), e) =>
-          val elem = fromSMT(e, base)
-          FiniteSet(elems.filter(_ != elem) :+ elem, base)
-        case (s, e) => SetAdd(s, fromSMT(e))
-      }
-
-      case (Union(e1, e2), Some(SetType(base))) =>
-        (fromSMT(e1, SetType(base)), fromSMT(e2, SetType(base))) match {
-          case (FiniteSet(elems1, _), FiniteSet(elems2, _)) => FiniteSet(elems1 ++ elems2, base)
-          case (s1, s2) => SetUnion(s1, s2)
-        }
-
-      case (Union(e1, e2), _) =>
-        (fromSMT(e1), fromSMT(e2)) match {
-          case (fs1@FiniteSet(elems1, b1), fs2@FiniteSet(elems2, b2)) =>
-            val tpe = leastUpperBound(b1, b2)
-            if (tpe == Untyped) unsupported(SetUnion(fs1, fs2), "woot? incompatible set base-types")
-            FiniteSet(elems1 ++ elems2, tpe)
-          case (s1, s2) => SetUnion(s1, s2)
-        }
 
       case (ArraysEx.Store(e1, e2, e3), Some(MapType(from, to))) =>
         (fromSMT(e1, MapType(from, to)), fromSMT(e2, from), fromSMT(e3, to)) match {
@@ -113,32 +69,6 @@ trait CVCTarget extends SMTLIBTarget with SMTLIBDebugger {
   }
 
   override protected def toSMT(e: Expr)(using bindings: Map[Identifier, Term]) = e match {
-    case fs@FiniteSet(elems, _) =>
-      if (elems.isEmpty) {
-        EmptySet(declareSort(fs.getType))
-      } else {
-        val selems = elems.map(toSMT)
-
-        if (exprOps.variablesOf(elems.head).isEmpty) {
-          val sgt = Singleton(selems.head)
-
-          if (selems.size > 1) {
-            Insert(selems.tail :+ sgt)
-          } else {
-            sgt
-          }
-        } else {
-          val sgt = EmptySet(declareSort(fs.getType))
-          Insert(selems :+ sgt)
-        }
-      }
-    case SubsetOf(ss, s) => Subset(toSMT(ss), toSMT(s))
-    case ElementOfSet(e, s) => Member(toSMT(e), toSMT(s))
-    case SetDifference(a, b) => Setminus(toSMT(a), toSMT(b))
-    case SetUnion(a, b) => Union(toSMT(a), toSMT(b))
-    case SetAdd(a, b) => Insert(toSMT(b), toSMT(a))
-    case SetIntersection(a, b) => Intersection(toSMT(a), toSMT(b))
-
     case FiniteMap(_, default, _, _) if !isValue(default) || exprOps.exists {
       case _: Lambda => true
       case _ => false

--- a/src/main/scala/inox/solvers/smtlib/EldaricaTarget.scala
+++ b/src/main/scala/inox/solvers/smtlib/EldaricaTarget.scala
@@ -5,15 +5,8 @@ package solvers
 package smtlib
 
 import _root_.smtlib.trees.Terms.{Identifier => SMTIdentifier, _}
-import _root_.smtlib.trees.Commands._
-import _root_.smtlib.theories._
-import _root_.smtlib.theories.cvc._
+import _root_.smtlib.theories.cvc.{Sets, CVC5Sets}
 
-trait EldaricaTarget extends SMTLIBTarget with SMTLIBDebugger {
-  import context.{given, _}
-  import program._
-  import program.trees._
-  import program.symbols.{given, _}
-
-  override protected def toSMT(e: Expr)(using bindings: Map[Identifier, Term]) = super.toSMT(e)
+trait EldaricaTarget extends SMTLIBTarget with SMTSets with SMTLIBDebugger {
+  val setTarget: Sets = CVC5Sets // Eldarica (and Princess) use cvc5 set syntax
 }

--- a/src/main/scala/inox/solvers/smtlib/SMTSets.scala
+++ b/src/main/scala/inox/solvers/smtlib/SMTSets.scala
@@ -1,0 +1,97 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package inox
+package solvers
+package smtlib
+
+import _root_.smtlib.trees.Terms.{Term, Sort}
+import _root_.smtlib.theories.cvc.Sets
+
+trait SMTSets extends SMTLIBTarget with SMTLIBDebugger {
+  import context.{given, _}
+  import program._
+  import program.trees._
+  import program.symbols.{given, _}
+
+  protected val setTarget: Sets
+  import setTarget._
+
+  override protected def computeSort(t: Type): Sort = t match {
+    case SetType(base) => SetSort(declareSort(base))
+    case _ => super.computeSort(t)
+  }
+
+  override protected def fromSMT(t: Term, otpe: Option[Type] = None)(using Context): Expr = {
+    (t, otpe) match {
+      case (EmptySet(sort), Some(SetType(base))) => FiniteSet(Seq.empty, base)
+      case (EmptySet(sort), _) => FiniteSet(Seq.empty, fromSMT(sort))
+
+      case (Singleton(e), Some(SetType(base))) => FiniteSet(Seq(fromSMT(e, base)), base)
+      case (Singleton(e), _) =>
+        val elem = fromSMT(e)
+        FiniteSet(Seq(elem), elem.getType)
+
+      case (Insert(set, es@_*), Some(SetType(base))) => es.foldLeft(fromSMT(set, SetType(base))) {
+        case (FiniteSet(elems, base), e) =>
+          val elem = fromSMT(e, base)
+          FiniteSet(elems.filter(_ != elem) :+ elem, base)
+        case (s, e) => SetAdd(s, fromSMT(e, base))
+      }
+
+      case (Insert(set, es@_*), _) => es.foldLeft(fromSMT(set)) {
+        case (FiniteSet(elems, base), e) =>
+          val elem = fromSMT(e, base)
+          FiniteSet(elems.filter(_ != elem) :+ elem, base)
+        case (s, e) => SetAdd(s, fromSMT(e))
+      }
+
+      case (Union(e1, e2), Some(SetType(base))) =>
+        (fromSMT(e1, SetType(base)), fromSMT(e2, SetType(base))) match {
+          case (FiniteSet(elems1, _), FiniteSet(elems2, _)) => FiniteSet(elems1 ++ elems2, base)
+          case (s1, s2) => SetUnion(s1, s2)
+        }
+
+      case (Union(e1, e2), _) =>
+        (fromSMT(e1), fromSMT(e2)) match {
+          case (fs1@FiniteSet(elems1, b1), fs2@FiniteSet(elems2, b2)) =>
+            val tpe = leastUpperBound(b1, b2)
+            if (tpe == Untyped) unsupported(SetUnion(fs1, fs2), "woot? incompatible set base-types")
+            FiniteSet(elems1 ++ elems2, tpe)
+          case (s1, s2) => SetUnion(s1, s2)
+        }
+
+      case _ => super.fromSMT(t, otpe)
+    }
+  }
+
+  override protected def toSMT(e: Expr)(using bindings: Map[Identifier, Term]) = e match {
+    case fs@FiniteSet(elems, _) =>
+      if (elems.isEmpty) {
+        EmptySet(declareSort(fs.getType))
+      } else {
+        val selems = elems.map(toSMT)
+
+        if (exprOps.variablesOf(elems.head).isEmpty) {
+          val sgt = Singleton(selems.head)
+
+          if (selems.size > 1) {
+            Insert(selems.tail :+ sgt)
+          } else {
+            sgt
+          }
+        } else {
+          val sgt = EmptySet(declareSort(fs.getType))
+          Insert(selems :+ sgt)
+        }
+      }
+    case SubsetOf(ss, s) => Subset(toSMT(ss), toSMT(s))
+    case ElementOfSet(e, s) => Member(toSMT(e), toSMT(s))
+    case SetDifference(a, b) => Setminus(toSMT(a), toSMT(b))
+    case SetUnion(a, b) => Union(toSMT(a), toSMT(b))
+    case SetAdd(a, b) => Insert(toSMT(b), toSMT(a))
+    case SetIntersection(a, b) => Intersection(toSMT(a), toSMT(b))
+
+    case _ =>
+      super.toSMT(e)
+  }
+}

--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -310,7 +310,7 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
     case SubsetOf(ss, s) =>
       // a isSubset b   ==>   (a zip b).map(implies) == (* => true)
       val allTrue = ArrayConst(declareSort(s.getType), True())
-      SMTEquals(ArrayMap(SSymbol("implies"), toSMT(ss), toSMT(s)), allTrue)
+      SMTEquals(ArrayMap(SSymbol("=>"), toSMT(ss), toSMT(s)), allTrue)
 
     case SetAdd(s, e) =>
       ArraysEx.Store(toSMT(s), toSMT(e), True())

--- a/src/test/scala/inox/solvers/SemanticsSuite.scala
+++ b/src/test/scala/inox/solvers/SemanticsSuite.scala
@@ -655,6 +655,14 @@ class SemanticsSuite extends AnyFunSuite {
         FiniteSet(Seq(Int32Literal(2)), Int32Type())
       )))
     )) contains true)
+
+    assert(s.solveVALID(
+       SubsetOf(
+         FiniteSet(Seq(Int32Literal(1)), Int32Type()),
+         FiniteSet(Seq(Int32Literal(1), Int32Literal(2)), Int32Type())
+       )
+      ) contains true)
+
   }
 
   test("Z3 Set Extraction", filterSolvers(_, princess = true, cvc4 = true, cvc5 = true)) { ctx =>


### PR DESCRIPTION
Major:
- Add support for Princess extensional arrays, and by extension sets
- the Princess solver now supports Maps, Sets, and Bags (WIP)
- Set support for SMTLIB solvers is factored into a separate file, and this support is extended to Eldarica

Minor:
- Change z3 subset check to use the more standard `(_ map =>)`, which now allows using sets with Spacer as well

Issues:
- currently needs princess and eldarica nightlies
- Semantics suite for sets on Princess fails on some set tests due to simplifier issues that happen before even getting to princess, which I haven't yet managed to understand  