### PR TITLE
Handle short form of z3 `(_ map op)` in model parsing

### DIFF
--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -235,16 +235,22 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
         val set = fromSMT(arr, st)
         IfExpr(fromSMT(elem, BooleanType()), SetAdd(set, fromSMT(key, base)), set)
 
+      // Matches (_ map or) in both long form (_ map (or (Bool Bool) Bool))
+      // and short form (_ map or).
       case (FunctionApplication(
         QualifiedIdentifier(SMTIdentifier(SSymbol("map"),
-          List(SList(List(SSymbol("or"), SList(List(SSymbol("Bool"), SSymbol("Bool"))), SSymbol("Bool"))))), None),
+          List(SList(List(SSymbol("or"), SList(List(SSymbol("Bool"), SSymbol("Bool"))), SSymbol("Bool")))
+            | SSymbol("or"))), None),
         Seq(s1, s2)
       ), _) =>
         fromSMTUnifyType(s1, s2, otpe)((e1, e2) => SetUnion(extractSet(e1), extractSet(e2)))
 
+      // Matches (_ map and) in both long form (_ map (and (Bool Bool) Bool))
+      // and short form (_ map and).
       case (FunctionApplication(
         QualifiedIdentifier(SMTIdentifier(SSymbol("map"),
-          List(SList(List(SSymbol("and"), SList(List(SSymbol("Bool"), SSymbol("Bool"))), SSymbol("Bool"))))), None),
+          List(SList(List(SSymbol("and"), SList(List(SSymbol("Bool"), SSymbol("Bool"))), SSymbol("Bool")))
+            | SSymbol("and"))), None),
         Seq(s1, s2)
       ), _) =>
         fromSMTUnifyType(s1, s2, otpe)((e1, e2) => SetIntersection(extractSet(e1), extractSet(e2)))
@@ -277,9 +283,12 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
       ), None) =>
         MapUpdated(fromSMT(arr), fromSMT(key), fromSMT(elem))
 
+      // Matches (_ map ite) in both long form (_ map (ite (Bool T T) T))
+      // and short form (_ map ite).
       case (FunctionApplication(
         QualifiedIdentifier(SMTIdentifier(SSymbol("map"),
-          List(SList(List(SSymbol("ite"), SList(List(SSymbol("Bool"), _, _, _)), _)))), None),
+          List(SList(List(SSymbol("ite"), SList(List(SSymbol("Bool"), _, _, _)), _))
+            | SSymbol("ite"))), None),
         Seq(mask, map1, map2)
       ), _) =>
         MapMerge(fromSMT(mask), fromSMT(map1), fromSMT(map2))


### PR DESCRIPTION
z3 sometimes returns `(_ map or)` instead of the fully-qualified `(_ map (or (Bool Bool) Bool))` form, and similarly for `and` and `ite`. This caused a `MissformedSMTException` when parsing models.

Fixes https://github.com/epfl-lara/inox/issues/236