### PR TITLE
Disable fail-fast in CI matrix

### DIFF
--- a/.github/workflows/inox-CI.yml
+++ b/.github/workflows/inox-CI.yml
@@ -11,6 +11,7 @@ jobs:
     name: ${{ matrix.runners.name }} / JDK ${{ matrix.java-version }}
     runs-on: ${{ matrix.runners.labels }}
     strategy:
+      fail-fast: false
       matrix:
         runners:
           - name: Linux


### PR DESCRIPTION
Keep all matrix jobs running even if one fails, so we get results from all platforms and JDK versions.