### PR TITLE
CI: run tests regardless of pull request draft status

### DIFF
--- a/.github/workflows/inox-CI.yml
+++ b/.github/workflows/inox-CI.yml
@@ -7,7 +7,6 @@ on:
       - main
 jobs:
   tests:
-    if: github.event.pull_request.draft == false
     name: ${{ matrix.runners.name }} / JDK ${{ matrix.java-version }}
     runs-on: ${{ matrix.runners.labels }}
     strategy:


### PR DESCRIPTION
The `if: github.event.pull_request.draft == false` condition was evaluated against the original event payload, which meant a PR opened as a draft and then marked ready never ran tests (and re-runs reuse the stale payload).

Removing the condition altogether so tests always run.