### PR TITLE
Add rlimit option for smt z3 and smt cvc5

### DIFF
--- a/src/main/scala/inox/Main.scala
+++ b/src/main/scala/inox/Main.scala
@@ -104,6 +104,8 @@ trait MainHelpers {
     solvers.unrolling.optModelFinding -> Description(Solvers, "Enhance model-finding capabilities of solvers by given aggressivity"),
     solvers.smtlib.optCVC4Options -> Description(Solvers, "Pass extra options to CVC4"),
     solvers.smtlib.optCVC5Options -> Description(Solvers, "Pass extra options to CVC5"),
+    solvers.smtlib.optZ3Rlimit -> Description(Solvers, "Set z3's resource limit (deterministic alternative to a wall clock timeout, 0 = no limit).\nOnly applies to the smt-z3 solvers"),
+    solvers.smtlib.optCVC5Rlimit -> Description(Solvers, "Set cvc5's resource limit (deterministic alternative to a wall clock timeout, 0 = no limit).\nOnly applies to the smt-cvc5 solver"),
     solvers.smtlib.cvcSimplesModelOpt -> Description(Solvers, "Use --model-cores=simple with cvc family solvers to produce simpler models when queries are sat"),
     evaluators.optMaxCalls -> Description(Evaluators, "Maximum function invocations allowed during evaluation"),
     evaluators.optIgnoreContracts -> Description(Evaluators, "Don't fail on invalid contracts during evaluation")

--- a/src/main/scala/inox/solvers/Solver.scala
+++ b/src/main/scala/inox/solvers/Solver.scala
@@ -33,6 +33,10 @@ trait AbstractSolver extends Interruptible {
   // Therefore it should be overriden in solvers that extends SMTLibDebugger traits
   def getSmtLibFileId: Option[Int] = None
 
+  // Whether the last `check` returned Unknown because the solver exhausted its
+  // resource limit (e.g. --z3-rlimit or --cvc5-rlimit)
+  def resourceLimitReached: Boolean = false
+
   object SolverUnsupportedError {
     def msg(t: Tree, reason: Option[String]) = {
       s"(of ${t.getClass}) is unsupported by solver $name" + reason.map(":\n  " + _ ).getOrElse("")

--- a/src/main/scala/inox/solvers/SolverFactory.scala
+++ b/src/main/scala/inox/solvers/SolverFactory.scala
@@ -396,6 +396,8 @@ object SolverFactory {
 
           // Used to report SMT Lib files <-> VCs correspondence
           override def getSmtLibFileId: Option[Int] = underlying.getSmtLibFileId
+
+          override def resourceLimitReached: Boolean = underlying.resourceLimitReached
         }
 
         () => new SMTZ3Impl(p)(enc)(ChooseEncoder(p)(enc))
@@ -425,6 +427,8 @@ object SolverFactory {
 
           // Used to report SMT Lib files <-> VCs correspondence
           override def getSmtLibFileId: Option[Int] = underlying.getSmtLibFileId
+
+          override def resourceLimitReached: Boolean = underlying.resourceLimitReached
 
           // encoder is from TipDebugger and enc from AbstractUnrollingSolver
           override protected val encoder = enc
@@ -457,6 +461,8 @@ object SolverFactory {
 
           // Used to report SMT Lib files <-> VCs correspondence
           override def getSmtLibFileId: Option[Int] = underlying.getSmtLibFileId
+
+          override def resourceLimitReached: Boolean = underlying.resourceLimitReached
           
           // encoder is from TipDebugger and enc from AbstractUnrollingSolver
           override protected val encoder = enc
@@ -489,6 +495,8 @@ object SolverFactory {
 
           // Used to report SMT Lib files <-> VCs correspondence
           override def getSmtLibFileId: Option[Int] = underlying.getSmtLibFileId
+
+          override def resourceLimitReached: Boolean = underlying.resourceLimitReached
 
           // encoder is from TipDebugger and enc from AbstractUnrollingSolver
           override protected val encoder = enc

--- a/src/main/scala/inox/solvers/combinators/NonIncrementalSolver.scala
+++ b/src/main/scala/inox/solvers/combinators/NonIncrementalSolver.scala
@@ -23,6 +23,10 @@ trait NonIncrementalSolver extends AbstractSolver { self =>
     case Some(solver) => solver.getSmtLibFileId
     case None => None
 
+  override def resourceLimitReached: Boolean = currentSolver match
+    case Some(solver) => solver.resourceLimitReached
+    case None => false
+
   val assertions: IncrementalSeq[Trees] = new IncrementalSeq[Trees]
 
   var currentSolver: Option[AbstractSolver] = None

--- a/src/main/scala/inox/solvers/combinators/PortfolioSolver.scala
+++ b/src/main/scala/inox/solvers/combinators/PortfolioSolver.scala
@@ -23,6 +23,8 @@ trait PortfolioSolver extends Solver { self =>
   // Used to report SMT Lib files <-> VCs correspondence
   override def getSmtLibFileId: Option[Int] = if solvers.isEmpty then None else solvers.head.getSmtLibFileId
 
+  override def resourceLimitReached: Boolean = solvers.exists(_.resourceLimitReached)
+
   protected var resultSolver: Option[Solver] = None
 
   private var tasks: Future[Unit] = Future(())

--- a/src/main/scala/inox/solvers/smtlib/CVC5Solver.scala
+++ b/src/main/scala/inox/solvers/smtlib/CVC5Solver.scala
@@ -13,6 +13,15 @@ object optCVC5Options extends SetOptionDef[String] {
   val usageRhs = "<cvc5-opt>"
 }
 
+object optCVC5Rlimit extends LongOptionDef("cvc5-rlimit", 0L, "<N>")
+
 trait CVC5Solver extends CVCSolver with CVC5Target {
+  import context.{given, _}
+
   override def optCVCOptions: SetOptionDef[String] = optCVC5Options
+
+  override def interpreterOpts = {
+    val rlimit = options.findOptionOrDefault(optCVC5Rlimit)
+    super.interpreterOpts ++ (if (rlimit > 0) Seq(s"--rlimit=$rlimit") else Seq())
+  }
 }

--- a/src/main/scala/inox/solvers/smtlib/SMTLIBSolver.scala
+++ b/src/main/scala/inox/solvers/smtlib/SMTLIBSolver.scala
@@ -42,6 +42,37 @@ abstract class SMTLIBSolver private(override val program: Program,
 
   override def getSmtLibFileId: Option[Int] = this.getSmtLibFileIdIfDebug
 
+  private var resourceOut: Boolean = false
+
+  override def resourceLimitReached: Boolean = resourceOut
+
+  /** Whether the given `(get-info :reason-unknown)` answer denotes resource
+    * exhaustion (z3 answers "max. resource limit exceeded", cvc5 answers
+    * "resourceout"). Can be refined per solver.
+    */
+  protected def isResourceOutReason(reason: String): Boolean =
+    reason.toLowerCase.contains("resource")
+
+  /** Queries the solver for the reason behind the last `unknown` response and
+    * records whether it was caused by resource exhaustion.
+    *
+    * We emit a raw s-expression instead of `GetInfo(ReasonUnknownInfoFlag())`
+    * because scala-smtlib only parses the reasons standardized in SMT-LIB
+    * (timeout, memout, incomplete) and fails on solver-specific ones.
+    */
+  protected def updateResourceOut(): Unit = {
+    resourceOut = emit(SList(SSymbol("get-info"), SKeyword("reason-unknown"))) match {
+      case SList(List(SKeyword("reason-unknown"), reason)) =>
+        val str = reason match {
+          case SString(s) => s
+          case SSymbol(s) => s
+          case _ => ""
+        }
+        isResourceOutReason(str)
+      case _ => false
+    }
+  }
+
   /* Public solver interface */
   def assertCnstr(expr: Expr): Unit = {
     variablesOf(expr).foreach(declareVariable)
@@ -139,8 +170,12 @@ abstract class SMTLIBSolver private(override val program: Program,
       } else {
         Unsat
       }
-    case CheckSatStatus(UnknownStatus) => Unknown
-    case e                             => Unknown
+    case CheckSatStatus(UnknownStatus) =>
+      updateResourceOut()
+      Unknown
+    case e =>
+      updateResourceOut()
+      Unknown
   })
 
   def check(config: CheckConfiguration): config.Response[Model, Assumptions] =

--- a/src/main/scala/inox/solvers/smtlib/Z3Solver.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Solver.scala
@@ -11,6 +11,14 @@ trait Z3Solver extends SMTLIBSolver with Z3Target { self =>
   import program.trees._
   import SolverResponses._
 
+  // When interrupted by its resource limit, z3 answers "canceled" for
+  // check-sat with assumptions (and "max. resource limit exceeded" for plain
+  // check-sat), so we only interpret it as a resource-out when a resource
+  // limit was actually configured.
+  override protected def isResourceOutReason(reason: String): Boolean =
+    super.isResourceOutReason(reason) ||
+    (context.options.findOptionOrDefault(optZ3Rlimit) > 0 && reason.toLowerCase.contains("canceled"))
+
   protected lazy val evaluator: evaluators.DeterministicEvaluator { val program: self.program.type } =
     semantics.getEvaluator(using context.withOpts(evaluators.optIgnoreContracts(true)))
 

--- a/src/main/scala/inox/solvers/smtlib/Z3Target.scala
+++ b/src/main/scala/inox/solvers/smtlib/Z3Target.scala
@@ -18,6 +18,8 @@ import _root_.smtlib.theories._
 
 import utils._
 
+object optZ3Rlimit extends LongOptionDef("z3-rlimit", 0L, "<N>")
+
 trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
   import context.{given, _}
   import program._
@@ -26,10 +28,13 @@ trait Z3Target extends SMTLIBTarget with SMTLIBDebugger {
 
   def targetName = "z3"
 
-  protected def interpreterOpts = Seq(
-    "-in",
-    "-smt2"
-  )
+  protected def interpreterOpts = {
+    val rlimit = options.findOptionOrDefault(optZ3Rlimit)
+    Seq(
+      "-in",
+      "-smt2"
+    ) ++ (if (rlimit > 0) Seq(s"rlimit=$rlimit") else Seq())
+  }
 
   protected class Z3Parser(lexer: Lexer) extends Parser(lexer) {
     // Z3 uses a non-standard version of get-unsat-assumptions-response that


### PR DESCRIPTION
From my experience, `--z3-rlimit=40000000` corresponds to around 10sec timeout on my Macbook with M3 Pro.