### PR TITLE
Fix Princess indefinite wait in Portfolio

### DIFF
--- a/src/main/scala/inox/solvers/combinators/PortfolioSolver.scala
+++ b/src/main/scala/inox/solvers/combinators/PortfolioSolver.scala
@@ -82,7 +82,19 @@ trait PortfolioSolver extends Solver { self =>
     //
     // We should not be waiting for more than 50ms~ in practice (polling time
     // for Princess). 
-    fs.foreach(Await.ready(_, 100.milliseconds))
+    fs.zip(solvers).foreach { case (fut, solver) =>
+      // comfortably large timeout
+      val timeout = 5.seconds
+      try Await.ready(fut, timeout)
+      catch {
+        case _: TimeoutException =>
+          val msg =
+            s"Solver ${solver.name} in portfolio did not finish within the $timeout timeout after being interrupted." +
+            " Report this as a bug to the solver developers." +
+            " Continuing can leave the solver in an unstable state."
+          reporter.fatalError(msg)
+      }
+    }
     res
   }
 

--- a/src/main/scala/inox/solvers/combinators/PortfolioSolver.scala
+++ b/src/main/scala/inox/solvers/combinators/PortfolioSolver.scala
@@ -61,23 +61,29 @@ trait PortfolioSolver extends Solver { self =>
       }
     }
 
-    inox.utils.FutureUtils.findFirst(fs)(_._2 != Unknown) match {
-      case Some((s, r)) =>
-        resultSolver = s.getResultSolver
-        resultSolver.foreach { solv =>
-          reporter.debug("Solved with "+solv)
-        }
-        solvers.foreach(_.interrupt())
-        r
-      case None =>
-        reporter.debug("No solver succeeded")
-        config.cast(Unknown)
-    }
+    val res =
+      inox.utils.FutureUtils.findFirst(fs)(_._2 != Unknown) match {
+        case Some((s, r)) =>
+          resultSolver = s.getResultSolver
+          resultSolver.foreach { solv =>
+            reporter.debug("Solved with "+solv)
+          }
+          solvers.foreach(_.interrupt())
+          r
+        case None =>
+          reporter.debug("No solver succeeded")
+          config.cast(Unknown)
+      }
 
-    // TODO: Decide if we really want to wait for all the solvers.
-    // I understand we interrupt them, but what if one gets stuck
-    // fs foreach { Await.ready(_, Duration.Inf) }
-    // res
+    // @sg: wait for all the solvers to actually finish/be interrupted. This can
+    // otherwise cause an invalid prover state if we start another check while
+    // the previous one is in an unfinished state. In Princess for example, this
+    // would cause the next check to get completely stuck.
+    //
+    // We should not be waiting for more than 50ms~ in practice (polling time
+    // for Princess). 
+    fs.foreach(Await.ready(_, 100.milliseconds))
+    res
   }
 
 

--- a/src/main/scala/inox/solvers/princess/AbstractPrincessSolver.scala
+++ b/src/main/scala/inox/solvers/princess/AbstractPrincessSolver.scala
@@ -613,7 +613,7 @@ abstract class AbstractPrincessSolver(override val program: Program,
   def assertCnstr(formula: Trees): Unit = p !! formula.asInstanceOf[IFormula]
 
   // we interrupt asynchronously in portfolio mode, so this should be handled in a thread-safe manner
-  private var interruptCheckSat = new java.util.concurrent.atomic.AtomicBoolean(false)
+  private val interruptCheckSat = new java.util.concurrent.atomic.AtomicBoolean(false)
 
   private def internalCheck(config: Configuration): config.Response[Model, Assumptions] = {
     import SimpleAPI.ProverStatus

--- a/src/main/scala/inox/solvers/princess/AbstractPrincessSolver.scala
+++ b/src/main/scala/inox/solvers/princess/AbstractPrincessSolver.scala
@@ -52,7 +52,7 @@ abstract class AbstractPrincessSolver(override val program: Program,
   ap.util.Debug enableAllAssertions enableAssertions
   protected[princess] val p = SimpleAPI(
     enableAssert = enableAssertions,
-    dumpScala = enableAssertions,
+    dumpScala = false,
     scalaDumpBasename = options.findOptionOrDefault(Main.optFiles).headOption.map(_.getName).getOrElse("NA") + "-",
     dumpSMT = enableAssertions,
     dumpDirectory = if (enableAssertions) {

--- a/src/main/scala/inox/solvers/princess/AbstractPrincessSolver.scala
+++ b/src/main/scala/inox/solvers/princess/AbstractPrincessSolver.scala
@@ -612,17 +612,18 @@ abstract class AbstractPrincessSolver(override val program: Program,
 
   def assertCnstr(formula: Trees): Unit = p !! formula.asInstanceOf[IFormula]
 
-  private var interruptCheckSat = false
+  // we interrupt asynchronously in portfolio mode, so this should be handled in a thread-safe manner
+  private var interruptCheckSat = new java.util.concurrent.atomic.AtomicBoolean(false)
 
   private def internalCheck(config: Configuration): config.Response[Model, Assumptions] = {
     import SimpleAPI.ProverStatus
 
-    interruptCheckSat = false
+    interruptCheckSat.set(false)
 
     p checkSat false
 
     while ((p getStatus 50) == ProverStatus.Running) {
-      if (interruptCheckSat) p stop true
+      if (interruptCheckSat.get) p stop true
     }
 
     config.cast(p.getStatus(true) match {
@@ -709,5 +710,5 @@ abstract class AbstractPrincessSolver(override val program: Program,
     p.reset
   }
 
-  def interrupt() = interruptCheckSat = true
+  def interrupt() = interruptCheckSat.set(true)
 }


### PR DESCRIPTION
- makes portfolio wait for solvers to be correctly interrupted (as commented code already suggested)
- not doing this can cause a new check to be started before the solver (read Princess) is correctly interrupted, causing an invalid state where the proper is waiting for a new task indefinitely without a producer for one
- made the Princess interrupt flag atomic just to be safe in the future, although `@volatile` might suffice for our use.
- turned off the old Princess dumpScala option, as it does not support some types of ADTs etc and I ran into several errors while debugging this on @samuelchassot 's provided Stainless example.

Not sure if we should wait `Duration.Inf` to be safe, or yovo (You-Only-need-to-Verify-Once) it after 100 ms as I have currently set it. 